### PR TITLE
The TS produces an "outcome" file containing additional context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv
 # test outputs
 test/privcount.results.pdf
 test/privcount.tallies.*.json
+test/privcount.outcome.*.json


### PR DESCRIPTION
The outcome file contains:
* Tally (existing "tallies" file)
* Context
  * Count: Q, Sigma
  * DC: Name / UID / IP
  * SK: UID / IP
  * Time: ClockPadding, Period, Start, Stop

Resolves https://github.com/robgjansen/privcount/issues/6
Instead of adding the "fingerprint" (which privcount doesn't seem to know), I added DC name and IP.