### PR TITLE
Add contextual information to privcount results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv
 # test outputs
 test/privcount.results.pdf
 test/privcount.tallies.*.json
+test/privcount.outcome.*.json

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -422,7 +422,9 @@ class TorControlClientProtocol(LineOnlyReceiver):
             if event != '':
                 if not self.factory.handle_event(event):
                     self.quit()
-        # log any non-privcount responses
+        # log any non-privcount responses at an appropriate level
+        elif line == "250 OK":
+            logging.debug("Connection with {}:{}:{}: ok response: '{}'".format(peer.type, peer.host, peer.port, line))
         elif self.state == 'processing' and line.startswith("5"):
             logging.warning("Connection with {}:{}:{}: unexpected response: '{}'".format(peer.type, peer.host, peer.port, line))
         elif self.state == 'processing' and line.startswith("2"):

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -326,9 +326,10 @@ class TorControlClientProtocol(LineOnlyReceiver):
 
     def lineReceived(self, line): # overrides twisted function
         peer = self.transport.getPeer()
+        line = line.strip()
         logging.debug("Received line '{}' from {}:{}:{}".format(line, peer.type, peer.host, peer.port))
 
-        if self.state == 'authenticating' and line.strip() == "250 OK":
+        if self.state == 'authenticating' and line == "250 OK":
             # Just ask for all the info all at once
             self.sendLine("GETCONF Nickname")
             self.sendLine("GETCONF ORPort")
@@ -346,7 +347,7 @@ class TorControlClientProtocol(LineOnlyReceiver):
                     logging.warning("Connection with {}:{}:{}: bad nickname {}".format(peer.type, peer.host, peer.port, nickname))
             # It doesn't have a Nickname, maybe it's a client?
             # But we'll catch that when we check the fingerprint, so just ignore this response
-            elif line.strip() == "250 Nickname":
+            elif line == "250 Nickname":
                 logging.info("Connection with {}:{}:{}: no Nickname".format(peer.type, peer.host, peer.port))
             # It's a relay, and it's just told us its ORPort
             elif line.startswith("250 ORPort="):
@@ -355,7 +356,7 @@ class TorControlClientProtocol(LineOnlyReceiver):
                     logging.warning("Connection with {}:{}:{}: bad ORPort {}".format(peer.type, peer.host, peer.port, orport))
             # It doesn't have an ORPort, maybe it's a client?
             # But we'll catch that when we check the fingerprint, so just ignore this response
-            elif line.strip() == "250 ORPort":
+            elif line == "250 ORPort":
                 logging.warning("Connection with {}:{}:{}: no ORPort".format(peer.type, peer.host, peer.port))
             # It's a relay, and it's just told us its DirPort
             elif line.startswith("250 DirPort="):
@@ -363,7 +364,7 @@ class TorControlClientProtocol(LineOnlyReceiver):
                 if not self.factory.set_dirport(dirport):
                     logging.warning("Connection with {}:{}:{}: bad DirPort {}".format(peer.type, peer.host, peer.port, dirport))
             # It doesn't have an DirPort, just ignore the response
-            elif line.strip() == "250 DirPort":
+            elif line == "250 DirPort":
                 logging.info("Connection with {}:{}:{}: no DirPort".format(peer.type, peer.host, peer.port))
             # It's just told us its version
             # The control spec assumes that Tor always has a version, so there's no error case
@@ -379,7 +380,7 @@ class TorControlClientProtocol(LineOnlyReceiver):
                     logging.warning("Connection with {}:{}:{}: bad address {}".format(peer.type, peer.host, peer.port, address))
                 self.state = 'skip_ok'
             # We asked for its address, and it couldn't find it. That's weird.
-            elif line.strip() == "551 Address unknown":
+            elif line == "551 Address unknown":
                 logging.info("Connection with {}:{}:{}: does not know its own address".format(peer.type, peer.host, peer.port))
             # -- These are the terminating cases, they must end in processing or quit() --
             # It's a relay, and it's just told us its fingerprint
@@ -390,20 +391,20 @@ class TorControlClientProtocol(LineOnlyReceiver):
                 # processing mode will skip any unrecognised lines, such as "250 OK"
                 self.state = 'processing'
             # We asked for its fingerprint, and it said it's a client
-            elif line.strip() == "551 Not running in server mode":
+            elif line == "551 Not running in server mode":
                 logging.warning("Connection with {}:{}:{} failed: not a relay".format(peer.type, peer.host, peer.port))
                 self.quit()
             # something unexpectedly bad happened
             elif line.startswith("5"):
-                logging.warning("Connection with {}:{}:{} failed: unexpected error response: '{}'".format(peer.type, peer.host, peer.port, line.strip()))
+                logging.warning("Connection with {}:{}:{} failed: unexpected error response: '{}'".format(peer.type, peer.host, peer.port, line))
                 self.quit()
             # something unexpected, but ok happened
             elif line.startswith("2"):
-                logging.info("Connection with {}:{}:{}: unexpected OK response: '{}'".format(peer.type, peer.host, peer.port, line.strip()))
+                logging.info("Connection with {}:{}:{}: unexpected OK response: '{}'".format(peer.type, peer.host, peer.port, line))
                 self.state = 'processing'
             # something unexpected happened, let's assume it's ok
             else:
-                logging.warning("Connection with {}:{}:{} failed: unexpected response: '{}'".format(peer.type, peer.host, peer.port, line.strip()))
+                logging.warning("Connection with {}:{}:{} failed: unexpected response: '{}'".format(peer.type, peer.host, peer.port, line))
                 self.state = 'processing'
 
             # we're done with discovering context, let's start processing events
@@ -411,10 +412,10 @@ class TorControlClientProtocol(LineOnlyReceiver):
                 self.sendLine("SETEVENTS PRIVCOUNT")
         elif self.state == 'skip_ok':
             # just skip one OK line
-            if line.strip() == "250 OK":
+            if line == "250 OK":
                 self.state = 'discovering'
             else:
-                logging.warning("Connection with {}:{}:{} failed: unexpected response: '{}'".format(peer.type, peer.host, peer.port, line.strip()))
+                logging.warning("Connection with {}:{}:{} failed: unexpected response: '{}'".format(peer.type, peer.host, peer.port, line))
                 self.quit()
         elif self.state == 'processing' and line.startswith("650 PRIVCOUNT "):
             _, _, event = line.partition(" PRIVCOUNT ") # returns: part1, separator, part2
@@ -423,9 +424,9 @@ class TorControlClientProtocol(LineOnlyReceiver):
                     self.quit()
         # log any non-privcount responses
         elif self.state == 'processing' and line.startswith("5"):
-            logging.warning("Connection with {}:{}:{}: unexpected response: '{}'".format(peer.type, peer.host, peer.port, line.strip()))
+            logging.warning("Connection with {}:{}:{}: unexpected response: '{}'".format(peer.type, peer.host, peer.port, line))
         elif self.state == 'processing' and line.startswith("2"):
-            logging.info("Connection with {}:{}:{}: ok response: '{}'".format(peer.type, peer.host, peer.port, line.strip()))
+            logging.info("Connection with {}:{}:{}: ok response: '{}'".format(peer.type, peer.host, peer.port, line))
 
     def quit(self):
         self.sendLine("QUIT")

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -329,22 +329,93 @@ class TorControlClientProtocol(LineOnlyReceiver):
         logging.debug("Received line '{}' from {}:{}:{}".format(line, peer.type, peer.host, peer.port))
 
         if self.state == 'authenticating' and line.strip() == "250 OK":
+            # Just ask for all the info all at once
+            self.sendLine("GETCONF Nickname")
+            self.sendLine("GETCONF ORPort")
+            self.sendLine("GETCONF DirPort")
+            self.sendLine("GETINFO version")
+            self.sendLine("GETINFO address")
             self.sendLine("GETINFO fingerprint")
             self.state = 'discovering'
         elif self.state == 'discovering':
-            # Looks like a client
-            if line.strip() == "551 Not running in server mode":
-                logging.warning("Connection with {}:{}:{} failed: not a relay".format(peer.type, peer.host, peer.port))
-                self.quit()
+            # -- These are the continuing cases, they can continue discovering, skip_ok, or quit() --
+            # It's a relay, and it's just told us its Nickname
+            if line.startswith("250 Nickname="):
+                _, _, nickname = line.partition("Nickname=") # returns: part1, separator, part2
+                if not self.factory.set_nickname(nickname):
+                    logging.warning("Connection with {}:{}:{}: bad nickname {}".format(peer.type, peer.host, peer.port, nickname))
+            # It doesn't have a Nickname, maybe it's a client?
+            # But we'll catch that when we check the fingerprint, so just ignore this response
+            elif line.strip() == "250 Nickname":
+                logging.info("Connection with {}:{}:{}: no Nickname".format(peer.type, peer.host, peer.port))
+            # It's a relay, and it's just told us its ORPort
+            elif line.startswith("250 ORPort="):
+                _, _, orport = line.partition("ORPort=") # returns: part1, separator, part2
+                if not self.factory.set_orport(orport):
+                    logging.warning("Connection with {}:{}:{}: bad ORPort {}".format(peer.type, peer.host, peer.port, orport))
+            # It doesn't have an ORPort, maybe it's a client?
+            # But we'll catch that when we check the fingerprint, so just ignore this response
+            elif line.strip() == "250 ORPort":
+                logging.warning("Connection with {}:{}:{}: no ORPort".format(peer.type, peer.host, peer.port))
+            # It's a relay, and it's just told us its DirPort
+            elif line.startswith("250 DirPort="):
+                _, _, dirport = line.partition("DirPort=") # returns: part1, separator, part2
+                if not self.factory.set_dirport(dirport):
+                    logging.warning("Connection with {}:{}:{}: bad DirPort {}".format(peer.type, peer.host, peer.port, dirport))
+            # It doesn't have an DirPort, just ignore the response
+            elif line.strip() == "250 DirPort":
+                logging.info("Connection with {}:{}:{}: no DirPort".format(peer.type, peer.host, peer.port))
+            # It's just told us its version
+            # The control spec assumes that Tor always has a version, so there's no error case
+            elif line.startswith("250-version="):
+                _, _, version = line.partition("version=") # returns: part1, separator, part2
+                if not self.factory.set_version(version):
+                    logging.warning("Connection with {}:{}:{}: bad version {}".format(peer.type, peer.host, peer.port, version))
+                self.state = 'skip_ok'
+            # It's just told us its address
+            elif line.startswith("250-address="):
+                _, _, address = line.partition("address=") # returns: part1, separator, part2
+                if not self.factory.set_address(address):
+                    logging.warning("Connection with {}:{}:{}: bad address {}".format(peer.type, peer.host, peer.port, address))
+                self.state = 'skip_ok'
+            # We asked for its address, and it couldn't find it. That's weird.
+            elif line.strip() == "551 Address unknown":
+                logging.info("Connection with {}:{}:{}: does not know its own address".format(peer.type, peer.host, peer.port))
+            # -- These are the terminating cases, they must end in processing or quit() --
             # It's a relay, and it's just told us its fingerprint
             elif line.startswith("250-fingerprint="):
                 _, _, fingerprint = line.partition("fingerprint=") # returns: part1, separator, part2
                 if not self.factory.set_fingerprint(fingerprint):
-                    self.quit()
-            # the fingerprint response has finished, let's start processing events
-            elif line.strip() == "250 OK":
-                self.sendLine("SETEVENTS PRIVCOUNT")
+                    logging.warning("Connection with {}:{}:{}: bad fingerprint {}".format(peer.type, peer.host, peer.port, fingerprint))
+                # processing mode will skip any unrecognised lines, such as "250 OK"
                 self.state = 'processing'
+            # We asked for its fingerprint, and it said it's a client
+            elif line.strip() == "551 Not running in server mode":
+                logging.warning("Connection with {}:{}:{} failed: not a relay".format(peer.type, peer.host, peer.port))
+                self.quit()
+            # something unexpectedly bad happened
+            elif line.startswith("5"):
+                logging.warning("Connection with {}:{}:{} failed: unexpected error response: '{}'".format(peer.type, peer.host, peer.port, line.strip()))
+                self.quit()
+            # something unexpected, but ok happened
+            elif line.startswith("2"):
+                logging.info("Connection with {}:{}:{}: unexpected OK response: '{}'".format(peer.type, peer.host, peer.port, line.strip()))
+                self.state = 'processing'
+            # something unexpected happened, let's assume it's ok
+            else:
+                logging.warning("Connection with {}:{}:{} failed: unexpected response: '{}'".format(peer.type, peer.host, peer.port, line.strip()))
+                self.state = 'processing'
+
+            # we're done with discovering context, let's start processing events
+            if self.state == 'processing':
+                self.sendLine("SETEVENTS PRIVCOUNT")
+        elif self.state == 'skip_ok':
+            # just skip one OK line
+            if line.strip() == "250 OK":
+                self.state = 'discovering'
+            else:
+                logging.warning("Connection with {}:{}:{} failed: unexpected response: '{}'".format(peer.type, peer.host, peer.port, line.strip()))
+                self.quit()
         elif self.state == 'processing' and line.startswith("650 PRIVCOUNT "):
             _, _, event = line.partition(" PRIVCOUNT ") # returns: part1, separator, part2
             if event != '':
@@ -383,6 +454,10 @@ class TorControlServerProtocol(LineOnlyReceiver):
     250 OK
     GETINFO blah
     552 Unrecognized key "blah"
+    GETCONF Nickname
+    250 Nickname=Unnamed
+    GETCONF foo
+    552 Unrecognized configuration key "foo"
     SETEVENTS PRIVCOUNT
     552 Unrecognized event "PRIVCOUNT"
     SETEVENTS BW
@@ -431,6 +506,14 @@ class TorControlServerProtocol(LineOnlyReceiver):
                 if len(parts) == 1:
                     self.sendLine("250 OK")
                 # GETINFO is case-sensitive, and returns multiple lines
+                # The control spec says we should say "Tor ", but tor doesn't
+                elif len(parts) == 2 and parts[1] == "version":
+                    self.sendLine("250-version=0.2.8.6 (git-4d217548e3f05569)")
+                    self.sendLine("250 OK")
+                elif len(parts) == 2 and parts[1] == "address":
+                    # TEST-NET from https://tools.ietf.org/html/rfc5737
+                    self.sendLine("250-address=192.0.2.91")
+                    self.sendLine("250 OK")
                 elif len(parts) == 2 and parts[1] == "fingerprint":
                     self.sendLine("250-fingerprint=FACADE0000000000000000000123456789ABCDEF")
                     self.sendLine("250 OK")
@@ -440,6 +523,24 @@ class TorControlServerProtocol(LineOnlyReceiver):
                     # But this is sufficient for our purposes, and is still
                     # more-or-less conformant to the control spec.
                     self.sendLine('552 Unrecognized key "{}"'.format(parts[1]))
+            elif parts[0] == "GETCONF":
+                # the correct response to an empty GETCONF is an empty OK
+                if len(parts) == 1:
+                    self.sendLine("250 OK")
+                # Unlike GETINFO, GETCONF is case-insensitive, and returns one line
+                # It also uses the canonical case of the option in its response
+                elif len(parts) == 2 and parts[1].lower() == "nickname":
+                    self.sendLine("250 Nickname=PrivCountTorRelay99")
+                elif len(parts) == 2 and parts[1].lower() == "orport":
+                    self.sendLine("250 ORPort=9001")
+                elif len(parts) == 2 and parts[1].lower() == "dirport":
+                    self.sendLine("250 DirPort=9030")
+                else:
+                    # strictly, GETCONF should process each word on the line
+                    # as a separate request for information.
+                    # But this is sufficient for our purposes, and is still
+                    # more-or-less conformant to the control spec.
+                    self.sendLine('552 Unrecognized configuration key "{}"'.format(parts[1]))
             elif parts[0] == "QUIT":
                 self.factory.stop_injecting()
                 self.sendLine("250 closing connection")

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -421,6 +421,11 @@ class TorControlClientProtocol(LineOnlyReceiver):
             if event != '':
                 if not self.factory.handle_event(event):
                     self.quit()
+        # log any non-privcount responses
+        elif self.state == 'processing' and line.startswith("5"):
+            logging.warning("Connection with {}:{}:{}: unexpected response: '{}'".format(peer.type, peer.host, peer.port, line.strip()))
+        elif self.state == 'processing' and line.startswith("2"):
+            logging.info("Connection with {}:{}:{}: ok response: '{}'".format(peer.type, peer.host, peer.port, line.strip()))
 
     def quit(self):
         self.sendLine("QUIT")

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -315,19 +315,20 @@ class TallyServer(ServerFactory):
         oldfingerprint = self.clients.get(uid, {}).get('fingerprint')
         fingerprint = status.get('fingerprint', oldfingerprint)
 
-        # uidfp includes the fingerprint for data collectors
-        if fingerprint is not None:
-            uidfp = uid + ' ' + fingerprint
-        else:
-            uidfp = uid
-
         # complain if fingerprint changes
         if (fingerprint is not None and oldfingerprint is not None and
             fingerprint != oldfingerprint):
             logging.warning("fingerprint of {} {} state {} changed from {} to {}".format(status['type'], uid, status['state'], oldfingerprint, fingerprint))
 
+        nickname = status.get('nickname', None)
+        # uidname includes the nickname for data collectors
+        if nickname is not None:
+            uidname = uid + ' ' + nickname
+        else:
+            uidname = uid
+
         if uid not in self.clients:
-            logging.info("new {} {} joined and is {}".format(status['type'], uidfp, status['state']))
+            logging.info("new {} {} joined and is {}".format(status['type'], uidname, status['state']))
 
         # for each key, replace the client value with the value from status,
         # or, if uid is a new client, initialise uid with status
@@ -338,7 +339,7 @@ class TallyServer(ServerFactory):
             self.clients[uid]['time'] = status['alive']
 
         minutes = int((time() - self.clients[uid]['time'])/ 60.0)
-        logging.info("----client status: {} {} is alive and {} for {} minutes (since {})".format(self.clients[uid]['type'], uidfp, self.clients[uid]['state'], minutes, self.clients[uid]['time']))
+        logging.info("----client status: {} {} is alive and {} for {} minutes (since {})".format(self.clients[uid]['type'], uidname, self.clients[uid]['state'], minutes, self.clients[uid]['time']))
 
     def get_clock_padding(self, client_uids):
         max_delay = max([self.clients[uid]['rtt']+self.clients[uid]['clock_skew'] for uid in client_uids])


### PR DESCRIPTION
This branch adds privcount and relay information to a separate "outcome" file, created next to the "tallies" file. (This avoids breaking existing scripts.)