### PR TITLE
Fix up some typos in the min and max counter value functions

### DIFF
--- a/privcount/util.py
+++ b/privcount/util.py
@@ -369,7 +369,7 @@ def min_tally_counter_value():
     The hard-coded minimum value for a tallied counter
     Tallied counters are signed, to allow for negative noise
     '''
-    return adjust_count_signed((counter_modulus() + 1)//2,
+    return adjust_count_signed((counter_modulus() + 1L)//2L,
                                counter_modulus())
 
 def max_tally_counter_value():
@@ -377,7 +377,7 @@ def max_tally_counter_value():
     The hard-coded maximum value for a tallied counter
     Tallied counters are signed, to allow for negative noise
     '''
-    return adjust_count_signed((counter_modulus() + 1)//2 - 1,
+    return adjust_count_signed((counter_modulus() + 1L)//2L - 1L,
                                counter_modulus())
 
 def add_counter_limits_to_config(config):


### PR DESCRIPTION
I left an argument out of these functions in the original branch.