### PR TITLE
Replace old uses of Hash() with DigestHash()

### DIFF
--- a/privcount/util.py
+++ b/privcount/util.py
@@ -454,8 +454,8 @@ def PRF(key, IV):
     Therefore, it must be at least 32 bytes long
     returns 32 pseudo-random bytes
     '''
-    assert len(key) >= Hash().digest_size
-    prv = Hash("PRF1|KEY:%s|IV:%s|" % (key, IV)).digest()
+    assert len(key) >= DigestHash().digest_size
+    prv = DigestHash("PRF1|KEY:%s|IV:%s|" % (key, IV)).digest()
     # for security, the key input must have at least as many bytes as the hash
     # output (we do not depend on the length or content of IV for security)
     assert len(key) >= len(prv)
@@ -497,7 +497,7 @@ def sample(s, modulus):
         if 0L <= v < modulus:
             break
         # when we reject the value, re-hash s and try again
-        s = Hash(s).digest()
+        s = DigestHash(s).digest()
     return v
 
 def derive_blinding_factor(label, secret, modulus, positive=True):
@@ -644,7 +644,7 @@ class SecureCounters(object):
         self.shares = {}
         for uid in uids:
             # the secret should be at least as large as the hash output
-            secret = urandom(Hash().digest_size)
+            secret = urandom(DigestHash().digest_size)
             hash_id = PRF(secret, "KEYID")
             self.shares[uid] = {'secret': secret, 'hash_id': hash_id}
             # add blinding factors to all of the counters

--- a/test/test_keyed_random.py
+++ b/test/test_keyed_random.py
@@ -9,7 +9,7 @@
 
 from os import urandom
 from random import randrange
-from privcount.util import sample, derive_blinding_factor, Hash, counter_modulus
+from privcount.util import sample, derive_blinding_factor, DigestHash, counter_modulus
 
 # Allow this much divergence from the full range and equal bin counts
 MAX_DIVERGENCE = 0.02
@@ -22,7 +22,7 @@ POSITIVE = True
 # this should be equal to privcount's hard-coded key length
 # key should contain at least 32 bytes of entropy, as the hash is 32 bytes
 # (this lack of entropy won't be apparent in the output, because it is hashed)
-PRIV_KEY_LEN = Hash().digest_size
+PRIV_KEY_LEN = DigestHash().digest_size
 
 # the hard-coded modulus value
 PRIV_COUNTER_MODULUS = counter_modulus()


### PR DESCRIPTION
refs #60

After these changes, I still get the following error during the integration test when running `run_test.sh`

```
2016-10-13 12:37:06 1476376626.206073 [privcount-dc] [ERROR] Fatal error: encryption hash {} unsupported, try upgrading to cryptography >= 1.4. Exception: <class 'cryptography.hazmat.primitives.hashes.SHA256'>
```

I have the following version installed:

```
(venv)[rjansen@sol test]$ pip show cryptography                                                                                              
---
Name: cryptography
Version: 1.5.2
Location: /home/rjansen/dev/privcount/venv/lib/python2.7/site-packages
Requires: idna, pyasn1, six, setuptools, enum34, ipaddress, cffi
```