### PR TITLE
Use latest packages in requirements, diff test results

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,7 +43,9 @@ Run the following from the base directory of this package (i.e., the same locati
     pip install virtualenv
     virtualenv --no-site-packages venv
     source venv/bin/activate
-    pip install -r requirements.txt # excludes the optional numpy and matplotlib libraries
+    pip install -r requirements.txt
+    # if you want to use the optional privcount plot command
+    pip install -r requirements-plot.txt
     pip install -I .
     test/run_test.sh . # run the unit tests to check your setup
     deactivate

--- a/requirements-plot.txt
+++ b/requirements-plot.txt
@@ -1,0 +1,8 @@
+# Requirements for privcount's optional plot command
+
+# PrivCount uses >= to download the latest package versions
+# This is particularly important for (non-backported) security fixes
+
+# Listed versions worked with privcount when the dependency was added
+matplotlib>=1.5.3
+numpy>=1.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,22 @@
-PyYAML==3.11
-Twisted==15.5.0
-attrs==15.2.0
-cffi==1.5.2
-cryptography==1.5.2
-enum34==1.1.2
-idna==2.0
-ipaddress==1.0.16
-pyOpenSSL==0.15.1
-pyasn1==0.1.9
-pyasn1-modules==0.0.8
-pycparser==2.14
-service-identity==16.0.0
-six==1.10.0
-wsgiref==0.1.2
-zope.interface==4.1.3
+# Requirements for privcount
+
+# PrivCount uses >= to download the latest package versions
+# This is particularly important for (non-backported) security fixes
+
+# Listed versions worked with privcount when the dependency was added
+PyYAML>=3.11
+Twisted>=15.5.0
+attrs>=15.2.0
+cffi>=1.5.2
+cryptography>=1.5.2 # must be >=1.4 for SHA256 hashes in RSA encryption
+enum34>=1.1.2
+idna>=2.0
+ipaddress>=1.0.16
+pyOpenSSL>=0.15.1
+pyasn1>=0.1.9
+pyasn1-modules>=0.0.8
+pycparser>=2.14
+service-identity>=16.0.0
+six>=1.10.0
+wsgiref>=0.1.2
+zope.interface>=4.1.3

--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,8 @@ setup(name='PrivCount',
       author='Rob Jansen',
       packages=['privcount'],
       scripts=['privcount/tools/privcount'],
+      # allow other packages to depend on "privcount [plot]"
+      extras_require={
+        'plot':  ['matplotlib', 'numpy']
+      }
      )

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -86,7 +86,7 @@ while echo "$JOB_STATUS" | grep -q "Running"; do
   if [ -f privcount.outcome.*.json ]; then
     break
   fi
-  sleep 1
+  sleep 2
   JOB_STATUS=`jobs`
   echo "$JOB_STATUS"
 done

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -78,7 +78,7 @@ while echo "$JOB_STATUS" | grep -q "Running"; do
   # fail if any job has failed
   if echo "$JOB_STATUS" | grep -q "Exit"; then
     # and kill everything
-    echo "Terminating privcount due to error..."
+    echo "Error: Privcount process exited with an error..."
     pkill -P $$
     exit 1
   fi


### PR DESCRIPTION
This branch modifies the PrivCount requirements.txt so that the latest version of each package is installed. It adds requirements-plot.txt for the optional plot requirements.

It improves the tests by checking that the outcomes file matches the previous outcomes file.
It also makes the test script more consistent, more reliable when plot dependencies aren't installed, and less verbose when checking process statuses.

To minimise the test differences, please reinstall your venv, or upgrade to the latest versions of each dependent package. Otherwise, you will see timing-dependent differences in some of the counts.