### PR TITLE
Configure noise weight at TS

### DIFF
--- a/privcount/data_collector.py
+++ b/privcount/data_collector.py
@@ -111,7 +111,7 @@ class DataCollector(ReconnectingClientFactory):
             if key in dc_counters and 'bins' in ts_counters[key]:
                 dc_counters[key]['bins'] = deepcopy(ts_counters[key]['bins'])
 
-        # we cant count keys for which we don't have configured bins
+        # we can't count keys for which we don't have configured bins
         for key in dc_counters:
             if 'bins' not in dc_counters[key]:
                 logging.warning("skipping counter '{}' because we do not have any bins configured".format(key))

--- a/privcount/data_collector.py
+++ b/privcount/data_collector.py
@@ -31,6 +31,7 @@ class DataCollector(ReconnectingClientFactory):
     def __init__(self, config_filepath):
         self.config_filepath = normalise_path(config_filepath)
         self.config = None
+        self.start_config = None
         self.aggregator = None
         self.aggregator_defer_id = None
         self.context = {}
@@ -97,6 +98,10 @@ class DataCollector(ReconnectingClientFactory):
         start the node running
         return None if failure, otherwise json will encode result
         '''
+        # keep the start config to send to the TS at the end of the collection
+        # deepcopy in case we make any modifications later
+        self.start_config = deepcopy(config)
+
         if ('sharekeepers' not in config or 'counters' not in config or
             'noise_weight' not in config or 'dc_threshold' not in config):
             return None
@@ -204,6 +209,9 @@ class DataCollector(ReconnectingClientFactory):
         logging.info("collection phase was stopped")
         # even though the counter limits are hard-coded, include them anyway
         response['Config'] = add_counter_limits_to_config(self.config)
+        # and include the config sent by the tally server in do_start
+        if self.start_config is not None:
+            response['Config']['Start'] = self.start_config
         return response
 
     def refresh_config(self):
@@ -558,8 +566,6 @@ class Aggregator(ReconnectingClientFactory):
             context['fingerprint'] = self.get_fingerprint()
         if self.last_event_time != 0.0:
             context['last_event_time'] = self.last_event_time
-        if self.noise_weight_config is not None:
-            context['noise_weight_config'] = self.noise_weight_config
         if self.noise_weight_value is not None:
             context['noise_weight_value'] = self.noise_weight_value
         return context

--- a/privcount/data_collector.py
+++ b/privcount/data_collector.py
@@ -10,7 +10,7 @@ from base64 import b64decode
 
 from protocol import PrivCountClientProtocol, TorControlClientProtocol
 from tally_server import log_tally_server_status
-from util import SecureCounters, log_error, get_public_digest_string, load_public_key_string, encrypt, format_delay_time_wait, format_last_event_time_since, normalise_path, counter_modulus, add_counter_limits_to_config
+from util import SecureCounters, log_error, get_public_digest_string, load_public_key_string, encrypt, format_delay_time_wait, format_last_event_time_since, normalise_path, counter_modulus, add_counter_limits_to_config, check_noise_weight_config
 
 import yaml
 
@@ -100,6 +100,12 @@ class DataCollector(ReconnectingClientFactory):
         if ('sharekeepers' not in config or 'counters' not in config or
             'noise_weight' not in config or 'dc_threshold' not in config):
             return None
+
+        # if the noise weights don't pass the validity checks, fail
+        if not check_noise_weight_config(config['noise_weight'],
+                                         config['dc_threshold']):
+            return None
+
         # if we are still running from a previous incarnation, we need to stop first
         if self.aggregator is not None:
             return None

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -16,7 +16,7 @@ from twisted.internet import reactor, task, ssl
 from twisted.internet.protocol import ServerFactory
 
 from protocol import PrivCountServerProtocol
-from util import log_error, SecureCounters, generate_keypair, generate_cert, format_elapsed_time_since, format_elapsed_time_since, format_delay_time_until, format_interval_time_between, format_last_event_time_since, normalise_path, counter_modulus, min_blinded_counter_value, max_blinded_counter_value, min_tally_counter_value, max_tally_counter_value, add_counter_limits_to_config
+from util import log_error, SecureCounters, generate_keypair, generate_cert, format_elapsed_time_since, format_elapsed_time_since, format_delay_time_until, format_interval_time_between, format_last_event_time_since, normalise_path, counter_modulus, min_blinded_counter_value, max_blinded_counter_value, min_tally_counter_value, max_tally_counter_value, add_counter_limits_to_config, check_noise_weight_config
 
 import yaml
 
@@ -225,6 +225,8 @@ class TallyServer(ServerFactory):
             assert ts_conf['sk_threshold'] > 0
             assert ts_conf['dc_threshold'] > 0
             assert ts_conf.has_key('noise_weight')
+            assert check_noise_weight_config(ts_conf['noise_weight'],
+                                             ts_conf['dc_threshold'])
             assert ts_conf['collect_period'] > 0
             assert ts_conf['event_period'] > 0
             assert ts_conf['checkin_period'] > 0

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -762,18 +762,29 @@ class CollectionPhase(object):
             result_context.update(self.get_client_context_by_type())
 
         # now remove any context we are sure we don't want
-        # We don't need the paths from the configs
-        for uid in result_context.get('DataCollector', {}):
-            if 'state' in result_context['DataCollector'][uid].get('Config', {}):
-                del result_context['DataCollector'][uid]['Config']['state']
+        for dc in result_context.get('DataCollector', {}).values():
+            # We don't need the paths from the configs
+            if 'state' in dc.get('Config', {}):
+                del dc['Config']['state']
+            # or the counters
+            if 'counters' in dc.get('Config', {}).get('Start',{}):
+                del dc['Config']['Start']['counters']
+            # or the sk public keys
+            if 'sharekeepers' in dc.get('Config', {}).get('Start',{}):
+                for uid in dc['Config']['Start']['sharekeepers']:
+                    dc['Config']['Start']['sharekeepers'][uid] = "(public key)"
+
         # We don't want the public key in the ShareKeepers' statuses
-        for uid in result_context.get('ShareKeeper', {}):
-            if 'key' in result_context['ShareKeeper'][uid].get('Config', {}):
-                del result_context['ShareKeeper'][uid]['Config']['key']
-            if 'state' in result_context['ShareKeeper'][uid].get('Config', {}):
-                del result_context['ShareKeeper'][uid]['Config']['state']
-            if 'public_key' in result_context['ShareKeeper'][uid].get('Status', {}):
-                del result_context['ShareKeeper'][uid]['Status']['public_key']
+        for sk in result_context.get('ShareKeeper', {}).values():
+            if 'key' in sk.get('Config', {}):
+                del sk['Config']['key']
+            if 'state' in sk.get('Config', {}):
+                del sk['Config']['state']
+            if 'public_key' in sk.get('Status', {}):
+                del sk['Status']['public_key']
+            # or the counters
+            if 'counters' in sk.get('Config', {}).get('Start',{}):
+                del sk['Config']['Start']['counters']
 
         # add the status and config for the tally server itself
         result_context['TallyServer'] = {}

--- a/privcount/util.py
+++ b/privcount/util.py
@@ -796,7 +796,8 @@ class SecureCounters(object):
     It is used approximately like this:
 
     data collector:
-    init(), generate(), detach_blinding_shares(), increment()[repeated],
+    init(), generate_blinding_shares(), detach_blinding_shares(),
+    generate_noise(), increment()[repeated],
     detach_counts()
     the blinding shares are sent to each share keeper
     the counts are sent to the tally server at the end
@@ -919,11 +920,10 @@ class SecureCounters(object):
         # failure here should be logged, and the counters ignored
         return self._derive_all_counters(blinding_factors, False)
 
-    def generate(self, uids, noise_weight):
+    def generate_blinding_shares(self, uids):
         '''
         Generate and apply blinding factors for each counter and share keeper
         uid.
-        Generate and apply noise for each counter.
         '''
         self.shares = {}
         for uid in uids:
@@ -932,6 +932,10 @@ class SecureCounters(object):
             # the caller can add additional annotations to this dictionary
             self.shares[uid] = {'secret': blinding_factors, 'sk_uid': uid}
 
+    def generate_noise(self, noise_weight):
+        '''
+        Generate and apply noise for each counter.
+        '''
         # generate noise for each counter independently
         noise_values = deepcopy(self.zero_counters)
         for key in noise_values:

--- a/privcount/util.py
+++ b/privcount/util.py
@@ -632,6 +632,91 @@ def add_counter_limits_to_config(config):
     config['max_tally_counter_value'] = max_tally_counter_value()
     return config
 
+MAX_DC_COUNT = 10**6
+
+def check_dc_threshold(dc_threshold, description="threshold"):
+    '''
+    Check that dc_threshold is a valid dc threshold.
+    DC thresholds must be positive non-zero, and less than or equal to
+    MAX_DC_COUNT.
+    Returns True if the dc threshold is valid.
+    Logs a specific warning using description and returns False if it is not.
+    '''
+    if dc_threshold <= 0:
+        logging.warning("Data collector {} must be at least 1, was {}"
+                        .format(description, dc_threshold))
+        return False
+    if dc_threshold > MAX_DC_COUNT:
+        logging.warning("Data collector {} can be at most {}, was {}"
+                        .format(description, MAX_DC_COUNT, dc_threshold))
+        return False
+    return True
+
+def check_noise_weight_value(noise_weight_value, description="value"):
+    '''
+    Check that noise_weight_value is a valid noise weight.
+    Noise weights must be positive and less than or equal to the maximum
+    tallied counter value.
+    Returns True if the noise weight value is valid.
+    Logs a specific warning using description, and returns False if it is not.
+    '''
+    if noise_weight_value < 0.0:
+        logging.warning("Noise weight {} must be positive, was {}".format(
+                description, noise_weight_value))
+        return False
+    if noise_weight_value > max_tally_counter_value():
+        logging.warning("Noise weight {} can be at most {}, was {}".format(
+                description, max_tally_counter_value(), noise_weight_value))
+        return False
+    return True
+
+def check_noise_weight_sum(noise_weight_sum, description="sum"):
+    '''
+    Check that noise_weight_sum is a valid summed noise weight.
+    Noise weight sums must not reduce the overall noise.
+    They must also pass check_noise_weight_value().
+    Returns True if the noise weight sum is valid.
+    Logs a specific warning using description and returns False if it is not.
+    '''
+    # Do the stricter check first, to produce accurate logs
+    if noise_weight_sum < 1.0:
+        logging.warning("Noise weight {} must be greater than 1.0, was {}"
+                        .format(description, noise_weight_sum))
+        return False
+    if not check_noise_weight_value(noise_weight_sum, description):
+        return False
+    return True
+
+def check_noise_weight_config(noise_weight_config, dc_threshold):
+    '''
+    Check that noise_weight_config is a valid noise weight configuration.
+    Each noise weight must also pass check_noise_weight_value().
+    Returns True if the noise weight config is valid.
+    Logs a specific warning and returns False if it is not.
+    '''
+    if not check_dc_threshold(dc_threshold):
+        return False
+    # there must be noise weights for a threshold of DCs
+    if len(noise_weight_config) < dc_threshold:
+        logging.warning("There must be at least as many noise weights as the threshold of data collectors. Noise weights: {}, Threshold: {}."
+                        .format(len(noise_weight_config), dc_threshold))
+        return False
+    # each noise weight must be individually valid
+    for dc in noise_weight_config:
+        if not check_noise_weight_value(noise_weight_config[dc]):
+            return False
+    # the sum must be valid
+    if not check_noise_weight_sum(sum(noise_weight_config.values())):
+        return False
+    # more strictly, the bottom dc_threshold of noise_weights must not
+    # reduce the total noise
+    sorted_noise_weights = sorted(noise_weight_config.values())
+    lowest_noise_weights = sorted_noise_weights[:dc_threshold]
+    if not check_noise_weight_sum(sum(lowest_noise_weights),
+                                  "sum of the lowest threshold"):
+        return False
+    return True
+
 def noise(sigma, sum_of_sq, p_exit):
     '''
     Sample noise from a gussian distribution

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -2,6 +2,9 @@
 tally_server:
     state: 'privcount.ts.state' # path to file where persistent state will be stored
     counters: './counters.bins.yaml' # path to a yaml file containing our counter bin configurations
+    noise_weight: # distribute noise among all machines / data collectors
+        # The tor relay fingerprints must be quoted, as some start with 0-9
+        'FACADE0000000000000000000123456789ABCDEF': 1.0
     listen_port: 20001 # open port on which to listen for remote connections from TKSes
     sk_threshold: 1 # number of share keeper nodes required before starting
     dc_threshold: 1 # number of data collector nodes required before starting
@@ -35,7 +38,6 @@ data_collector:
     state: 'privcount.dc.state' # path to file where persistent state will be stored
     counters: './counters.noise.yaml' # path to a yaml file containing our counter noise configurations
     event_source: 20003 # the Tor control port from which we will receive events
-    noise_weight: 1.0 # distribute noise among all machines / data collectors
     tally_server_info: # where the tally server is located
         ip: 127.0.0.1
         port: 20001

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -95,12 +95,15 @@ done
 ENDDATE=`date`
 ENDSEC="`date +%s`"
 
+# And terminate all the privcount processes
+echo "Terminating privcount..."
+pkill -P $$
+
 # If an outcome file was produced, keep a link to the latest file
 if [ -f privcount.outcome.*.json ]; then
   ln -s privcount.outcome.*.json privcount.outcome.latest.json
 else
   echo "Error: No outcome file produced."
-  pkill -P $$
   exit 1
 fi
 
@@ -113,18 +116,8 @@ if [ -f privcount.tallies.*.json ]; then
   privcount plot -d privcount.tallies.latest.json data || true
 else
   echo "Error: No tallies file produced."
-  pkill -P $$
   exit 1
 fi
-
-# And terminate all the privcount processes
-echo "Terminating privcount..."
-pkill -P $$
-
-# Show how long it took
-echo "$ENDDATE"
-ELAPSEDSEC=$[ $ENDSEC - $STARTSEC ]
-echo "Seconds Elapsed: $ELAPSEDSEC"
 
 # Show the differences between the latest and old latest outcome files
 if [ -e privcount.outcome.latest.json -a \
@@ -136,10 +129,15 @@ if [ -e privcount.outcome.latest.json -a \
   # events falling before or after data collection stops in short runs
   diff --minimal \
       -I "time" -I "[Cc]lock" -I "alive" -I "rtt" -I "Start" -I "Stop" \
-      old/privcount.outcome.latest.json privcount.outcome.latest.json
+      old/privcount.outcome.latest.json privcount.outcome.latest.json || true
 else
   # Since we need old/latest and latest, it takes two runs to generate the
   # first outcome file comparison
   echo "Warning: Outcomes files could not be compared."
   echo "$0 must be run twice to produce the first comparison."
 fi
+
+# Show how long it took
+echo "$ENDDATE"
+ELAPSEDSEC=$[ $ENDSEC - $STARTSEC ]
+echo "Seconds Elapsed: $ELAPSEDSEC"

--- a/test/test_counters.py
+++ b/test/test_counters.py
@@ -101,7 +101,8 @@ def create_counters(counters, modulus):
     returns a tuple containing a list of DCs and a list of SKs
     '''
     sc_dc = SecureCounters(counters, modulus)
-    sc_dc.generate(['sk1', 'sk2'], 1.0)
+    sc_dc.generate_blinding_shares(['sk1', 'sk2'])
+    sc_dc.generate_noise(1.0)
     check_blinding_values(sc_dc, modulus)
     # get the shares used to init the secure counters on the share keepers
     shares = sc_dc.detach_blinding_shares()


### PR DESCRIPTION
Configure the noise weight for each DC at the TS.
Uses the DC fingerprints as the identifiers of the DCs.
Adds noise once the DC fingerprint is known, or at the end of the round (if never known).
Do some sanity checks at the DCs and SKs. (More sanity checks to come in #27.)
Output the noise weights in the end-of-round TS and DC configs.
- (But not the SKs - I can do this if you think it's useful.)

Also fix a minor bug in the unit tests, and a typo in a comment.
