### PR TITLE
Noise weight at TS (revised)

### DIFF
--- a/privcount/data_collector.py
+++ b/privcount/data_collector.py
@@ -111,7 +111,7 @@ class DataCollector(ReconnectingClientFactory):
             if key in dc_counters and 'bins' in ts_counters[key]:
                 dc_counters[key]['bins'] = deepcopy(ts_counters[key]['bins'])
 
-        # we cant count keys for which we don't have configured bins
+        # we can't count keys for which we don't have configured bins
         for key in dc_counters:
             if 'bins' not in dc_counters[key]:
                 logging.warning("skipping counter '{}' because we do not have any bins configured".format(key))

--- a/privcount/share_keeper.py
+++ b/privcount/share_keeper.py
@@ -99,6 +99,7 @@ class ShareKeeper(ReconnectingClientFactory):
         for share in self.start_config.get('shares', []):
             # this is still encrypted, so there's no need for a secure delete
             del share['secret']
+            share['secret'] = "(encrypted blinding share, deleted by share keeper)"
 
         if ('shares' not in config or 'counters' not in config or
             'noise_weight' not in config or 'dc_threshold' not in config):
@@ -127,9 +128,13 @@ class ShareKeeper(ReconnectingClientFactory):
                 # but there is also no way to detect the TS modifying the data
                 logging.warning("failed to import blinding share {} config {}",
                                 share, config)
+                # TODO: secure delete
+                del private_key
                 return None
 
         logging.info("successfully started and imported {} blinding shares for {} counters".format(len(share_list), len(config['counters'])))
+        # TODO: secure delete
+        del private_key
         return {}
 
     def do_stop(self, config): # called by protocol

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -16,7 +16,7 @@ from twisted.internet import reactor, task, ssl
 from twisted.internet.protocol import ServerFactory
 
 from protocol import PrivCountServerProtocol
-from util import log_error, SecureCounters, generate_keypair, generate_cert, format_elapsed_time_since, format_elapsed_time_since, format_delay_time_until, format_interval_time_between, format_last_event_time_since, normalise_path, counter_modulus, min_blinded_counter_value, max_blinded_counter_value, min_tally_counter_value, max_tally_counter_value, add_counter_limits_to_config
+from util import log_error, SecureCounters, generate_keypair, generate_cert, format_elapsed_time_since, format_elapsed_time_since, format_delay_time_until, format_interval_time_between, format_last_event_time_since, normalise_path, counter_modulus, min_blinded_counter_value, max_blinded_counter_value, min_tally_counter_value, max_tally_counter_value, add_counter_limits_to_config, check_noise_weight_config
 
 import yaml
 
@@ -225,6 +225,8 @@ class TallyServer(ServerFactory):
             assert ts_conf['sk_threshold'] > 0
             assert ts_conf['dc_threshold'] > 0
             assert ts_conf.has_key('noise_weight')
+            assert check_noise_weight_config(ts_conf['noise_weight'],
+                                             ts_conf['dc_threshold'])
             assert ts_conf['collect_period'] > 0
             assert ts_conf['event_period'] > 0
             assert ts_conf['checkin_period'] > 0

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -762,18 +762,29 @@ class CollectionPhase(object):
             result_context.update(self.get_client_context_by_type())
 
         # now remove any context we are sure we don't want
-        # We don't need the paths from the configs
-        for uid in result_context.get('DataCollector', {}):
-            if 'state' in result_context['DataCollector'][uid].get('Config', {}):
-                del result_context['DataCollector'][uid]['Config']['state']
+        for dc in result_context.get('DataCollector', {}).values():
+            # We don't need the paths from the configs
+            if 'state' in dc.get('Config', {}):
+                del dc['Config']['state']
+            # or the counters
+            if 'counters' in dc.get('Config', {}).get('Start',{}):
+                del dc['Config']['Start']['counters']
+            # or the sk public keys
+            if 'sharekeepers' in dc.get('Config', {}).get('Start',{}):
+                for uid in dc['Config']['Start']['sharekeepers']:
+                    dc['Config']['Start']['sharekeepers'][uid] = "(public key)"
+
         # We don't want the public key in the ShareKeepers' statuses
-        for uid in result_context.get('ShareKeeper', {}):
-            if 'key' in result_context['ShareKeeper'][uid].get('Config', {}):
-                del result_context['ShareKeeper'][uid]['Config']['key']
-            if 'state' in result_context['ShareKeeper'][uid].get('Config', {}):
-                del result_context['ShareKeeper'][uid]['Config']['state']
-            if 'public_key' in result_context['ShareKeeper'][uid].get('Status', {}):
-                del result_context['ShareKeeper'][uid]['Status']['public_key']
+        for sk in result_context.get('ShareKeeper', {}).values():
+            if 'key' in sk.get('Config', {}):
+                del sk['Config']['key']
+            if 'state' in sk.get('Config', {}):
+                del sk['Config']['state']
+            if 'public_key' in sk.get('Status', {}):
+                del sk['Status']['public_key']
+            # or the counters
+            if 'counters' in sk.get('Config', {}).get('Start',{}):
+                del sk['Config']['Start']['counters']
 
         # add the status and config for the tally server itself
         result_context['TallyServer'] = {}

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -765,10 +765,10 @@ class CollectionPhase(object):
         for dc in result_context.get('DataCollector', {}).values():
             # We don't need the paths from the configs
             if 'state' in dc.get('Config', {}):
-                del dc['Config']['state']
+                dc['Config']['state'] = "(state path)"
             # or the counters
             if 'counters' in dc.get('Config', {}).get('Start',{}):
-                del dc['Config']['Start']['counters']
+                dc['Config']['Start']['counters'] = "(counters, no counts)"
             # or the sk public keys
             if 'sharekeepers' in dc.get('Config', {}).get('Start',{}):
                 for uid in dc['Config']['Start']['sharekeepers']:
@@ -777,14 +777,14 @@ class CollectionPhase(object):
         # We don't want the public key in the ShareKeepers' statuses
         for sk in result_context.get('ShareKeeper', {}).values():
             if 'key' in sk.get('Config', {}):
-                del sk['Config']['key']
+                sk['Config']['key'] = "(key path)"
             if 'state' in sk.get('Config', {}):
-                del sk['Config']['state']
+                sk['Config']['state'] = "(state path)"
             if 'public_key' in sk.get('Status', {}):
-                del sk['Status']['public_key']
+                sk['Status']['public_key'] = "(public key)"
             # or the counters
             if 'counters' in sk.get('Config', {}).get('Start',{}):
-                del sk['Config']['Start']['counters']
+                sk['Config']['Start']['counters'] = "(counters, no counts)"
 
         # add the status and config for the tally server itself
         result_context['TallyServer'] = {}
@@ -795,14 +795,14 @@ class CollectionPhase(object):
 
         # We don't need the paths from the configs
         if 'cert' in result_context['TallyServer']['Config']:
-            del result_context['TallyServer']['Config']['cert']
+            result_context['TallyServer']['Config']['cert'] = "(cert path)"
         if 'key' in result_context['TallyServer']['Config']:
-            del result_context['TallyServer']['Config']['key']
+            result_context['TallyServer']['Config']['key'] = "(key path)"
         if 'state' in result_context['TallyServer']['Config']:
-            del result_context['TallyServer']['Config']['state']
+            result_context['TallyServer']['Config']['state'] = "(state path)"
         # And we don't need the bins, they're duplicated in 'Tally'
         if 'counters' in result_context['TallyServer']['Config']:
-            del result_context['TallyServer']['Config']['counters']
+            result_context['TallyServer']['Config']['counters'] = "(counters, no counts)"
 
         return result_context
 

--- a/privcount/util.py
+++ b/privcount/util.py
@@ -724,7 +724,8 @@ class SecureCounters(object):
     It is used approximately like this:
 
     data collector:
-    init(), generate(), detach_blinding_shares(), increment()[repeated],
+    init(), generate_blinding_shares(), detach_blinding_shares(),
+    generate_noise(), increment()[repeated],
     detach_counts()
     the blinding shares are sent to each share keeper
     the counts are sent to the tally server at the end
@@ -847,11 +848,10 @@ class SecureCounters(object):
         # failure here should be logged, and the counters ignored
         return self._derive_all_counters(blinding_factors, False)
 
-    def generate(self, uids, noise_weight):
+    def generate_blinding_shares(self, uids):
         '''
         Generate and apply blinding factors for each counter and share keeper
         uid.
-        Generate and apply noise for each counter.
         '''
         self.shares = {}
         for uid in uids:
@@ -860,6 +860,10 @@ class SecureCounters(object):
             # the caller can add additional annotations to this dictionary
             self.shares[uid] = {'secret': blinding_factors, 'sk_uid': uid}
 
+    def generate_noise(self, noise_weight):
+        '''
+        Generate and apply noise for each counter.
+        '''
         # generate noise for each counter independently
         noise_values = deepcopy(self.zero_counters)
         for key in noise_values:

--- a/privcount/util.py
+++ b/privcount/util.py
@@ -560,6 +560,78 @@ def add_counter_limits_to_config(config):
     config['max_tally_counter_value'] = max_tally_counter_value()
     return config
 
+MAX_DC_COUNT = 10**6
+
+def check_dc_threshold(dc_threshold, description="threshold"):
+    '''
+    Check that dc_threshold is a valid dc threshold.
+    DC thresholds must be positive non-zero, and less than or equal to
+    MAX_DC_COUNT.
+    Returns True if the dc threshold is valid.
+    Logs a specific warning using description and returns False if it is not.
+    '''
+    if dc_threshold <= 0:
+        logging.warning("Data collector {} must be at least 1, was {}"
+                        .format(description, dc_threshold))
+        return False
+    if dc_threshold > MAX_DC_COUNT:
+        logging.warning("Data collector {} can be at most {}, was {}"
+                        .format(description, MAX_DC_COUNT, dc_threshold))
+        return False
+    return True
+
+def check_noise_weight_value(noise_weight_value, description="value"):
+    '''
+    Check that noise_weight_value is a valid noise weight.
+    Noise weights must be positive and less than or equal to the maximum
+    tallied counter value.
+    Returns True if the noise weight value is valid.
+    Logs a specific warning using description, and returns False if it is not.
+    '''
+    if noise_weight_value < 0.0:
+        logging.warning("Noise weight {} must be positive, was {}".format(
+                description, noise_weight_value))
+        return False
+    if noise_weight_value > max_tally_counter_value():
+        logging.warning("Noise weight {} can be at most {}, was {}".format(
+                description, max_tally_counter_value(), noise_weight_value))
+        return False
+    return True
+
+def check_noise_weight_sum(noise_weight_sum, description="sum"):
+    '''
+    Check that noise_weight_sum is a valid summed noise weight.
+    Noise weight sums must pass check_noise_weight_value().
+    Returns True if the noise weight sum is valid.
+    Logs a specific warning using description and returns False if it is not.
+    '''
+    if not check_noise_weight_value(noise_weight_sum, description):
+        return False
+    return True
+
+def check_noise_weight_config(noise_weight_config, dc_threshold):
+    '''
+    Check that noise_weight_config is a valid noise weight configuration.
+    Each noise weight must also pass check_noise_weight_value().
+    Returns True if the noise weight config is valid.
+    Logs a specific warning and returns False if it is not.
+    '''
+    if not check_dc_threshold(dc_threshold):
+        return False
+    # there must be noise weights for a threshold of DCs
+    if len(noise_weight_config) < dc_threshold:
+        logging.warning("There must be at least as many noise weights as the threshold of data collectors. Noise weights: {}, Threshold: {}."
+                        .format(len(noise_weight_config), dc_threshold))
+        return False
+    # each noise weight must be individually valid
+    for dc in noise_weight_config:
+        if not check_noise_weight_value(noise_weight_config[dc]):
+            return False
+    # the sum must be valid
+    if not check_noise_weight_sum(sum(noise_weight_config.values())):
+        return False
+    return True
+
 def noise(sigma, sum_of_sq, p_exit):
     '''
     Sample noise from a gussian distribution

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -2,6 +2,9 @@
 tally_server:
     state: 'privcount.ts.state' # path to file where persistent state will be stored
     counters: './counters.bins.yaml' # path to a yaml file containing our counter bin configurations
+    noise_weight: # distribute noise among all machines / data collectors
+        # The tor relay fingerprints must be quoted, as some start with 0-9
+        'FACADE0000000000000000000123456789ABCDEF': 1.0
     listen_port: 20001 # open port on which to listen for remote connections from TKSes
     sk_threshold: 1 # number of share keeper nodes required before starting
     dc_threshold: 1 # number of data collector nodes required before starting
@@ -35,7 +38,6 @@ data_collector:
     state: 'privcount.dc.state' # path to file where persistent state will be stored
     counters: './counters.noise.yaml' # path to a yaml file containing our counter noise configurations
     event_source: 20003 # the Tor control port from which we will receive events
-    noise_weight: 1.0 # distribute noise among all machines / data collectors
     tally_server_info: # where the tally server is located
         ip: 127.0.0.1
         port: 20001

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -4,7 +4,12 @@ tally_server:
     counters: './counters.bins.yaml' # path to a yaml file containing our counter bin configurations
     noise_weight: # distribute noise among all machines / data collectors
         # The tor relay fingerprints must be quoted, as some start with 0-9
+        # This is the fingerprint from the test data collector
+        # Comment it out to test the missing fingerprint failure case
         'FACADE0000000000000000000123456789ABCDEF': 1.0
+        # This fingerprint is not present on the test data collector,
+        # it should be ignored
+        '3DEADBEEF012345678900000000000000DEADC00': 1.0
     listen_port: 20001 # open port on which to listen for remote connections from TKSes
     sk_threshold: 1 # number of share keeper nodes required before starting
     dc_threshold: 1 # number of data collector nodes required before starting

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -100,12 +100,15 @@ done
 ENDDATE=`date`
 ENDSEC="`date +%s`"
 
+# And terminate all the privcount processes
+echo "Terminating privcount..."
+pkill -P $$
+
 # If an outcome file was produced, keep a link to the latest file
 if [ -f privcount.outcome.*.json ]; then
   ln -s privcount.outcome.*.json privcount.outcome.latest.json
 else
   echo "Error: No outcome file produced."
-  pkill -P $$
   exit 1
 fi
 
@@ -118,18 +121,8 @@ if [ -f privcount.tallies.*.json ]; then
   privcount plot -d privcount.tallies.latest.json data || true
 else
   echo "Error: No tallies file produced."
-  pkill -P $$
   exit 1
 fi
-
-# And terminate all the privcount processes
-echo "Terminating privcount..."
-pkill -P $$
-
-# Show how long it took
-echo "$ENDDATE"
-ELAPSEDSEC=$[ $ENDSEC - $STARTSEC ]
-echo "Seconds Elapsed: $ELAPSEDSEC"
 
 # Show the differences between the latest and old latest outcome files
 if [ -e privcount.outcome.latest.json -a \
@@ -141,10 +134,15 @@ if [ -e privcount.outcome.latest.json -a \
   # events falling before or after data collection stops in short runs
   diff --minimal \
       -I "time" -I "[Cc]lock" -I "alive" -I "rtt" -I "Start" -I "Stop" \
-      old/privcount.outcome.latest.json privcount.outcome.latest.json
+      old/privcount.outcome.latest.json privcount.outcome.latest.json || true
 else
   # Since we need old/latest and latest, it takes two runs to generate the
   # first outcome file comparison
   echo "Warning: Outcomes files could not be compared."
   echo "$0 must be run twice to produce the first comparison."
 fi
+
+# Show how long it took
+echo "$ENDDATE"
+ELAPSEDSEC=$[ $ENDSEC - $STARTSEC ]
+echo "Seconds Elapsed: $ELAPSEDSEC"

--- a/test/test_counters.py
+++ b/test/test_counters.py
@@ -101,7 +101,8 @@ def create_counters(counters, modulus):
     returns a tuple containing a list of DCs and a list of SKs
     '''
     sc_dc = SecureCounters(counters, modulus)
-    sc_dc.generate(['sk1', 'sk2'], 1.0)
+    sc_dc.generate_blinding_shares(['sk1', 'sk2'])
+    sc_dc.generate_noise(1.0)
     check_blinding_values(sc_dc, modulus)
     # get the shares used to init the secure counters on the share keepers
     shares = sc_dc.detach_blinding_shares()


### PR DESCRIPTION
Configure the noise weight for each DC at the TS.
Uses the DC fingerprints as the identifiers of the DCs.
Adds noise once the DC fingerprint is known.
Fail DC and delete counters if fingerprint is not present in TS config, or never received by DC.
Do noise weight sanity checks at the DCs and SKs. (More sanity checks to come in #27.)
Output the noise weights in the end-of-round context.
Make the end-of-round context clearer - add placeholders for deleted items.

Also fix a minor bug in the unit tests, and fix typos in some comments.