### PR TITLE
Redesign PrivCount Handshake to use HMAC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/privcount.results.pdf
 test/privcount.tallies.*.json
 test/privcount.outcome.*.json
 test/old
+test/keys/secret_handshake.yaml

--- a/README.markdown
+++ b/README.markdown
@@ -68,13 +68,27 @@ If the encryption unit tests fail with an "UnsupportedAlgorithm" exception, make
 
 # running
 
-To run PrivCount, simply activate the virtual environment that you created earlier and then run
-PrivCount as normal. For example:
+To run PrivCount, simply activate the virtual environment that you created earlier and then run PrivCount as normal. For example:
 
     source venv/bin/activate # enter the virtual environment
     privcount --help
     ...
     deactivate # exit the virtual environment
+
+# deployment
+
+## keys
+
+On first run, PrivCount creates the keys that it needs to run:
+
+The TallyServer creates a RSA key pair for SSL encryption:
+    * the clients do not check the fingerprint of the certificate
+
+The TallyServer creates a PrivCount secret handshake key:
+    * each ShareKeeper and DataCollector needs to know this key to successfully handshake with the TallyServer.
+
+Each ShareKeeper creates a RSA key pair for public key encryption:
+     * each DataCollector needs to know the SHA256 hash of the public key of each ShareKeeper
 
 # testing
 

--- a/privcount/data_collector.py
+++ b/privcount/data_collector.py
@@ -10,8 +10,7 @@ from base64 import b64decode
 
 from protocol import PrivCountClientProtocol, TorControlClientProtocol
 from tally_server import log_tally_server_status
-from util import SecureCounters, log_error, get_public_digest_string, load_public_key_string, encrypt, format_delay_time_wait, format_last_event_time_since, normalise_path, counter_modulus, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, combine_counters, choose_secret_handshake_path
-
+from util import SecureCounters, log_error, get_public_digest_string, load_public_key_string, encrypt, format_delay_time_wait, format_last_event_time_since, normalise_path, counter_modulus, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, combine_counters, choose_secret_handshake_path, PrivCountClient
 import yaml
 
 from twisted.internet import task, reactor, ssl
@@ -21,7 +20,7 @@ from twisted.internet.protocol import ReconnectingClientFactory
 # method docstring missing: pylint: disable=C0111
 # line too long: pylint: disable=C0301
 
-class DataCollector(ReconnectingClientFactory):
+class DataCollector(ReconnectingClientFactory, PrivCountClient):
     '''
     receive key share data from the DC message receiver
     keep the shares during collection epoch
@@ -261,15 +260,6 @@ class DataCollector(ReconnectingClientFactory):
         except KeyError:
             logging.warning("problem reading config file: missing required keys")
             log_error()
-
-    def get_secret_handshake_path(self):
-        '''
-        Return the path of the secret handshake key file, or None if the config
-        has not been loaded.
-        '''
-        # The secret handshake path should be loaded (or assigned a default)
-        # whenever the config is loaded
-        return self.config.get('secret_handshake')
 
 class Aggregator(ReconnectingClientFactory):
     '''

--- a/privcount/data_collector.py
+++ b/privcount/data_collector.py
@@ -9,7 +9,6 @@ from copy import deepcopy
 from base64 import b64decode
 
 from protocol import PrivCountClientProtocol, TorControlClientProtocol
-from tally_server import log_tally_server_status
 from util import SecureCounters, log_error, get_public_digest_string, load_public_key_string, encrypt, format_delay_time_wait, format_last_event_time_since, normalise_path, counter_modulus, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, combine_counters, choose_secret_handshake_path, PrivCountClient
 import yaml
 
@@ -28,38 +27,43 @@ class DataCollector(ReconnectingClientFactory, PrivCountClient):
     '''
 
     def __init__(self, config_filepath):
-        self.config_filepath = normalise_path(config_filepath)
-        self.config = None
-        self.start_config = None
+        PrivCountClient.__init__(self, config_filepath)
         self.aggregator = None
         self.aggregator_defer_id = None
         self.context = {}
 
     def buildProtocol(self, addr):
+        '''
+        Called by twisted
+        '''
         return PrivCountClientProtocol(self)
 
     def startFactory(self):
+        '''
+        Called by twisted
+        '''
         # TODO
         return
-        # load any state we may have from a previous run
-        state_filepath = normalise_path(self.config['state'])
-        if os.path.exists(state_filepath):
-            with open(state_filepath, 'r') as fin:
-                state = pickle.load(fin)
-                self.aggregator = state['aggregator']
-                self.aggregator_defer_id = state['aggregator_defer_id']
+        state = self.load_state()
+        if state is not None:
+            self.aggregator = state['aggregator']
+            self.aggregator_defer_id = state['aggregator_defer_id']
 
     def stopFactory(self):
+        '''
+        Called by twisted
+        '''
         # TODO
         return
-        state_filepath = normalise_path(self.config['state'])
         if self.aggregator is not None:
             # export everything that would be needed to survive an app restart
             state = {'aggregator': self.aggregator, 'aggregator_defer_id': self.aggregator_defer_id}
-            with open(state_filepath, 'w') as fout:
-                pickle.dump(state, fout)
+            self.dump_state(state)
 
     def run(self):
+        '''
+        Called by twisted
+        '''
         # load iniital config
         self.refresh_config()
         if self.config is None:
@@ -70,7 +74,11 @@ class DataCollector(ReconnectingClientFactory, PrivCountClient):
         self.do_checkin()
         reactor.run()
 
-    def get_status(self): # called by protocol
+    def get_status(self):
+        '''
+        Called by protocol
+        Returns a dictionary containing status information
+        '''
         status = {'type':'DataCollector', 'name':self.config['name'],
                   'state': 'active' if self.aggregator is not None else 'idle'}
         # store the latest context, so we have it even when the aggregator goes away
@@ -80,50 +88,43 @@ class DataCollector(ReconnectingClientFactory, PrivCountClient):
         status.update(self.context)
         return status
 
-    def set_server_status(self, status): # called by protocol
-        log_tally_server_status(status)
-
-    def do_checkin(self): # called by protocol
+    def do_checkin(self):
+        '''
+        Called by protocol
+        Refresh the config, and try to connect to the server
+        '''
+        # TODO: Refactor common client code - issue #121
         self.refresh_config()
-        # turn on reconnecting mode and reset backoff
-        self.resetDelay()
         ts_ip = self.config['tally_server_info']['ip']
         ts_port = self.config['tally_server_info']['port']
+        # turn on reconnecting mode and reset backoff
+        self.resetDelay()
         logging.info("checking in with TallyServer at {}:{}".format(ts_ip, ts_port))
         reactor.connectSSL(ts_ip, ts_port, self, ssl.ClientContextFactory()) # pylint: disable=E1101
 
-    def do_start(self, config): # called by protocol
+    def do_start(self, config):
         '''
-        start the node running
+        this is called by the protocol when we receive a command from the TS
+        to start a new collection phase
         return None if failure, otherwise json will encode result
         '''
         # keep the start config to send to the TS at the end of the collection
         # deepcopy in case we make any modifications later
         self.start_config = deepcopy(config)
 
-        if ('sharekeepers' not in config or 'counters' not in config or
-            'noise' not in config or 'noise_weight' not in config or
-            'dc_threshold' not in config):
+        if ('sharekeepers' not in config):
+            logging.warning("start command from tally server cannot be completed due to missing sharekeepers")
             return None
 
-        # if the counters don't pass the validity checks, fail
-        if not check_counters_config(config['counters'],
-                                     config['noise']['counters']):
-            return None
+        dc_counters = self.check_start_config(config)
 
-        # if the noise weights don't pass the validity checks, fail
-        if not check_noise_weight_config(config['noise_weight'],
-                                         config['dc_threshold']):
+        if dc_counters is None:
             return None
 
         # if we are still running from a previous incarnation, we need to stop
         # first
         if self.aggregator is not None:
             return None
-
-        # combine the bins and sigmas
-        dc_counters = combine_counters(config['counters'],
-                                       config['noise']['counters'])
 
         # we require that only the configured share keepers be used in the
         # collection phase, because we must be able to encrypt messages to them
@@ -176,12 +177,14 @@ class DataCollector(ReconnectingClientFactory, PrivCountClient):
         self.aggregator_defer_id = None
         self.aggregator.start()
 
-    def do_stop(self, config): # called by protocol
+    def do_stop(self, config):
         '''
+        called by protocol
         stop the node from running
         return a dictionary consisting of the DC's Config, and, if counting
         was successful, and the TS wants the counters, return the Counts
         '''
+        # TODO: refactor common code: see ticket #121
         logging.info("got command to stop collection phase")
         wants_counters = config.get('send_counters', False)
         logging.info("tally server {} final counts".format("wants" if wants_counters else "does not want"))
@@ -216,6 +219,7 @@ class DataCollector(ReconnectingClientFactory, PrivCountClient):
         '''
         re-read config and process any changes
         '''
+        # TODO: refactor common code: see ticket #121
         try:
             logging.debug("reading config file from '%s'", self.config_filepath)
 

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -401,6 +401,7 @@ class PrivCountProtocol(LineOnlyReceiver):
                                            self.privcount_role)
         h1 = "{} {}".format(prefix,
                             b64encode(self.server_cookie))
+        logging.debug("Sent handshake: {}".format(h1))
         assert self.handshake1_verify(h1)
         return h1
 
@@ -446,6 +447,7 @@ class PrivCountProtocol(LineOnlyReceiver):
         assert self.handshake2_verify(h2,
                                       self.handshake_secret(),
                                       self.server_cookie)
+        logging.debug("Sent handshake: {}".format(h2))
         return h2
 
     @staticmethod
@@ -516,6 +518,7 @@ class PrivCountProtocol(LineOnlyReceiver):
                                       self.handshake_secret(),
                                       self.server_cookie,
                                       self.client_cookie)
+        logging.debug("Sent handshake: {}".format(h3))
         return h3
 
     @staticmethod
@@ -561,6 +564,7 @@ class PrivCountProtocol(LineOnlyReceiver):
         h4 = "{} {}".format(prefix,
                             PrivCountProtocol.HANDSHAKE_SUCCESS)
         assert self.handshake4_verify(h4)
+        logging.debug("Sent handshake: {}".format(h4))
         return h4
 
     @staticmethod
@@ -615,6 +619,7 @@ class PrivCountProtocol(LineOnlyReceiver):
         assert not self.handshake4_verify(hf)
         # Check that it verifies as a correctly formatted failure message
         assert self.handshake_fail_verify(hf)
+        logging.debug("Sent handshake: {}".format(hf))
         return hf
 
     @staticmethod
@@ -740,6 +745,7 @@ class PrivCountServerProtocol(PrivCountProtocol):
         '''
         # reconstitute the event line
         event_line = event_type + ' ' + event_payload
+        logging.debug("Received handshake: {}".format(event_line))
 
         if event_type == PrivCountProtocol.HANDSHAKE2:
             self.client_cookie = self.handshake2_verify(
@@ -870,6 +876,7 @@ class PrivCountClientProtocol(PrivCountProtocol):
         '''
         # reconstitute the event line
         event_line = event_type + ' ' + event_payload
+        logging.debug("Received handshake: {}".format(event_line))
 
         if event_type == PrivCountProtocol.HANDSHAKE1:
             self.server_cookie = self.handshake1_verify(event_line)

--- a/privcount/share_keeper.py
+++ b/privcount/share_keeper.py
@@ -14,11 +14,11 @@ from twisted.internet.protocol import ReconnectingClientFactory
 
 from protocol import PrivCountClientProtocol
 from tally_server import log_tally_server_status
-from util import SecureCounters, log_error, get_public_digest, generate_keypair, get_serialized_public_key, load_private_key_file, decrypt, normalise_path, counter_modulus, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, combine_counters, choose_secret_handshake_path
+from util import SecureCounters, log_error, get_public_digest, generate_keypair, get_serialized_public_key, load_private_key_file, decrypt, normalise_path, counter_modulus, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, combine_counters, choose_secret_handshake_path, PrivCountClient
 
 import yaml
 
-class ShareKeeper(ReconnectingClientFactory):
+class ShareKeeper(ReconnectingClientFactory, PrivCountClient):
     '''
     receive key share data from the DC message receiver
     keep the shares during collection epoch
@@ -235,12 +235,3 @@ class ShareKeeper(ReconnectingClientFactory):
         except KeyError:
             logging.warning("problem reading config file: missing required keys")
             log_error()
-
-    def get_secret_handshake_path(self):
-        '''
-        Return the path of the secret handshake key file, or None if the config
-        has not been loaded.
-        '''
-        # The secret handshake path should be loaded (or assigned a default)
-        # whenever the config is loaded
-        return self.config.get('secret_handshake')

--- a/privcount/share_keeper.py
+++ b/privcount/share_keeper.py
@@ -14,7 +14,7 @@ from twisted.internet.protocol import ReconnectingClientFactory
 
 from protocol import PrivCountClientProtocol
 from tally_server import log_tally_server_status
-from util import SecureCounters, log_error, get_public_digest, generate_keypair, get_serialized_public_key, load_private_key_file, decrypt, normalise_path, counter_modulus, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, combine_counters
+from util import SecureCounters, log_error, get_public_digest, generate_keypair, get_serialized_public_key, load_private_key_file, decrypt, normalise_path, counter_modulus, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, combine_counters, choose_secret_handshake_path
 
 import yaml
 
@@ -194,6 +194,10 @@ class ShareKeeper(ReconnectingClientFactory):
                 conf = yaml.load(fin)
             sk_conf = conf['share_keeper']
 
+            # find the path for the secret handshake file
+            sk_conf['secret_handshake'] = choose_secret_handshake_path(
+                sk_conf, conf)
+
             # if key path is not specified, use default path
             if 'key' in sk_conf:
                 sk_conf['key'] = normalise_path(sk_conf['key'])
@@ -231,3 +235,12 @@ class ShareKeeper(ReconnectingClientFactory):
         except KeyError:
             logging.warning("problem reading config file: missing required keys")
             log_error()
+
+    def get_secret_handshake_path(self):
+        '''
+        Return the path of the secret handshake key file, or None if the config
+        has not been loaded.
+        '''
+        # The secret handshake path should be loaded (or assigned a default)
+        # whenever the config is loaded
+        return self.config.get('secret_handshake')

--- a/privcount/share_keeper.py
+++ b/privcount/share_keeper.py
@@ -13,7 +13,6 @@ from twisted.internet import reactor, ssl
 from twisted.internet.protocol import ReconnectingClientFactory
 
 from protocol import PrivCountClientProtocol
-from tally_server import log_tally_server_status
 from util import SecureCounters, log_error, get_public_digest, generate_keypair, get_serialized_public_key, load_private_key_file, decrypt, normalise_path, counter_modulus, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, combine_counters, choose_secret_handshake_path, PrivCountClient
 
 import yaml
@@ -26,35 +25,40 @@ class ShareKeeper(ReconnectingClientFactory, PrivCountClient):
     '''
 
     def __init__(self, config_filepath):
-        self.config_filepath = normalise_path(config_filepath)
-        self.config = None
-        self.start_config = None
+        PrivCountClient.__init__(self, config_filepath)
         self.keystore = None
 
     def buildProtocol(self, addr):
+        '''
+        Called by twisted
+        '''
         return PrivCountClientProtocol(self)
 
     def startFactory(self):
+        '''
+        Called by twisted
+        '''
         # TODO
         return
-        # load any state we may have from a previous run
-        state_filepath = normalise_path(self.config['state'])
-        if os.path.exists(state_filepath):
-            with open(state_filepath, 'r') as fin:
-                state = pickle.load(fin)
-                self.keystore = state['keystore']
+        state = self.load_state()
+        if state is not None:
+            self.keystore = state['keystore']
 
     def stopFactory(self):
+        '''
+        Called by twisted
+        '''
         # TODO
         return
-        state_filepath = normalise_path(self.config['state'])
         if self.keystore is not None:
             # export everything that would be needed to survive an app restart
             state = {'keystore': self.keystore}
-            with open(state_filepath, 'w') as fout:
-                pickle.dump(state, fout)
+            self.dump_state(state)
 
     def run(self):
+        '''
+        Called by twisted
+        '''
         # load initial config
         self.refresh_config()
         if self.config is None:
@@ -67,26 +71,32 @@ class ShareKeeper(ReconnectingClientFactory, PrivCountClient):
         self.do_checkin()
         reactor.run() # pylint: disable=E1101
 
-    def get_status(self): # called by protocol
+    def get_status(self):
+        '''
+        Called by protocol
+        Returns a dictionary containing status information
+        '''
         return {'type':'ShareKeeper', 'name':self.config['name'],
         'state': 'active' if self.keystore is not None else 'idle', 'public_key':get_serialized_public_key(self.config['key'])}
 
-    def set_server_status(self, status): # called by protocol
-        log_tally_server_status(status)
-
-    def do_checkin(self): # called by protocol
-        # turn on reconnecting mode and reset backoff
-        self.resetDelay()
+    def do_checkin(self):
+        '''
+        Called by protocol
+        Refresh the config, and try to connect to the server
+        '''
+        # TODO: Refactor common client code - issue #121
         self.refresh_config()
         ts_ip = self.config['tally_server_info']['ip']
         ts_port = self.config['tally_server_info']['port']
+        # turn on reconnecting mode and reset backoff
+        self.resetDelay()
         logging.info("checking in with TallyServer at {}:{}".format(ts_ip, ts_port))
         reactor.connectSSL(ts_ip, ts_port, self, ssl.ClientContextFactory()) # pylint: disable=E1101
 
-    def do_start(self, config): # called by protocol
+    def do_start(self, config):
         '''
-        this is called when we receive a command from the TS to start a new
-        collection phase
+        this is called by the protocol when we receive a command from the TS
+        to start a new collection phase
         return None if failure, otherwise the protocol will encode the result
         in json and send it back to TS
         '''
@@ -101,25 +111,16 @@ class ShareKeeper(ReconnectingClientFactory, PrivCountClient):
             del share['secret']
             share['secret'] = "(encrypted blinding share, deleted by share keeper)"
 
-        if ('shares' not in config or 'counters' not in config or
-            'noise' not in config or 'noise_weight' not in config or
-            'dc_threshold' not in config):
-            logging.warning("start command from tally server cannot be completed due to missing data")
+        if ('shares' not in config):
+            logging.warning("start command from tally server cannot be completed due to missing shares")
             return None
 
-        # if the counters don't pass the validity checks, fail
-        if not check_counters_config(config['counters'],
-                                     config['noise']['counters']):
-            return None
+        combined_counters = self.check_start_config(config)
 
-        # if the noise weights don't pass the validity checks, fail
-        if not check_noise_weight_config(config['noise_weight'],
-                                         config['dc_threshold']):
+        if combined_counters is None:
             return None
-
-        # combine the bins and sigmas
-        config['counters'] = combine_counters(config['counters'],
-                                              config['noise']['counters'])
+        else:
+            config['counters'] = combined_counters
 
         self.keystore = SecureCounters(config['counters'], counter_modulus())
         share_list = config['shares']
@@ -147,12 +148,15 @@ class ShareKeeper(ReconnectingClientFactory, PrivCountClient):
         del private_key
         return {}
 
-    def do_stop(self, config): # called by protocol
+    def do_stop(self, config):
         '''
+        called by protocol
         the TS wants us to stop the current collection phase
         they may or may not want us to send back our counters
-        return None if failure, otherwise json will encode result back to the TS
+        return None if failure, otherwise json will encode result back to the
+        TS
         '''
+        # TODO: refactor common code: see ticket #121
         logging.info("got command to stop collection phase")
         if 'send_counters' not in config:
             return None
@@ -186,6 +190,7 @@ class ShareKeeper(ReconnectingClientFactory, PrivCountClient):
         '''
         re-read config and process any changes
         '''
+        # TODO: refactor common code: see ticket #121
         try:
             logging.debug("reading config file from '%s'", self.config_filepath)
 

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -17,7 +17,7 @@ from twisted.internet.protocol import ServerFactory
 
 from protocol import PrivCountServerProtocol
 from statistics_noise import get_noise_allocation
-from util import log_error, SecureCounters, generate_keypair, generate_cert, format_elapsed_time_since, format_elapsed_time_wait, format_delay_time_until, format_interval_time_between, format_last_event_time_since, normalise_path, counter_modulus, min_blinded_counter_value, max_blinded_counter_value, min_tally_counter_value, max_tally_counter_value, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, choose_secret_handshake_path
+from util import log_error, SecureCounters, generate_keypair, generate_cert, format_elapsed_time_since, format_elapsed_time_wait, format_delay_time_until, format_interval_time_between, format_last_event_time_since, normalise_path, counter_modulus, min_blinded_counter_value, max_blinded_counter_value, min_tally_counter_value, max_tally_counter_value, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, choose_secret_handshake_path, PrivCountNode
 import yaml
 
 # for warning about logging function and format # pylint: disable=W1202
@@ -50,7 +50,7 @@ def log_tally_server_status(status):
     a, i = status['sks_active'], status['sks_idle']
     logging.info("--server status: ShareKeepers: have {}, need {}, {}/{} active, {}/{} idle".format(t, r, a, t, i, t))
 
-class TallyServer(ServerFactory):
+class TallyServer(ServerFactory, PrivCountNode):
     '''
     receive blinded counts from the DCs
     receive key shares from the SKs
@@ -333,15 +333,6 @@ class TallyServer(ServerFactory):
         except KeyError:
             logging.warning("problem reading config file: missing required keys")
             log_error()
-
-    def get_secret_handshake_path(self):
-        '''
-        Return the path of the secret handshake key file, or None if the config
-        has not been loaded.
-        '''
-        # The secret handshake path should be loaded (or assigned a default)
-        # whenever the config is loaded
-        return self.config.get('secret_handshake')
 
     def clear_dead_clients(self):
         now = time()

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -17,40 +17,13 @@ from twisted.internet.protocol import ServerFactory
 
 from protocol import PrivCountServerProtocol
 from statistics_noise import get_noise_allocation
-from util import log_error, SecureCounters, generate_keypair, generate_cert, format_elapsed_time_since, format_elapsed_time_wait, format_delay_time_until, format_interval_time_between, format_last_event_time_since, normalise_path, counter_modulus, min_blinded_counter_value, max_blinded_counter_value, min_tally_counter_value, max_tally_counter_value, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, choose_secret_handshake_path, PrivCountNode
+from util import log_error, SecureCounters, generate_keypair, generate_cert, format_elapsed_time_since, format_elapsed_time_wait, format_delay_time_until, format_interval_time_between, format_last_event_time_since, normalise_path, counter_modulus, min_blinded_counter_value, max_blinded_counter_value, min_tally_counter_value, max_tally_counter_value, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, choose_secret_handshake_path, PrivCountServer, log_tally_server_status
 import yaml
 
 # for warning about logging function and format # pylint: disable=W1202
 # for calling methods on reactor # pylint: disable=E1101
 
-def log_tally_server_status(status):
-    '''
-    clients must only use the expected end time for logging: the tally
-    server may end the round early, or extend it slightly to allow for
-    network round trip times
-    '''
-
-    # until the collection round starts, the tally server doesn't know when it
-    # is expected to end
-    expected_end_msg = ""
-    if 'expected_end_time' in status:
-        stopping_ts = status['expected_end_time']
-        # we're waiting for the collection to stop
-        if stopping_ts > time():
-            expected_end_msg = ", expect collection to end in {}".format(format_delay_time_until(stopping_ts, 'at'))
-        # we expect the collection to have stopped, and the TS should be
-        # collecting results
-        else:
-            expected_end_msg = ", expect collection has ended for {}".format(format_elapsed_time_since(stopping_ts, 'since'))
-    logging.info("--server status: PrivCount is {} for {}{}".format(status['state'], format_elapsed_time_since(status['time'], 'since'), expected_end_msg))
-    t, r = status['dcs_total'], status['dcs_required']
-    a, i = status['dcs_active'], status['dcs_idle']
-    logging.info("--server status: DataCollectors: have {}, need {}, {}/{} active, {}/{} idle".format(t, r, a, t, i, t))
-    t, r = status['sks_total'], status['sks_required']
-    a, i = status['sks_active'], status['sks_idle']
-    logging.info("--server status: ShareKeepers: have {}, need {}, {}/{} active, {}/{} idle".format(t, r, a, t, i, t))
-
-class TallyServer(ServerFactory, PrivCountNode):
+class TallyServer(ServerFactory, PrivCountServer):
     '''
     receive blinded counts from the DCs
     receive key shares from the SKs
@@ -59,42 +32,46 @@ class TallyServer(ServerFactory, PrivCountNode):
     '''
 
     def __init__(self, config_filepath):
-        self.config_filepath = normalise_path(config_filepath)
-        self.config = None
+        PrivCountServer.__init__(self, config_filepath)
         self.clients = {}
         self.collection_phase = None
         self.idle_time = time()
         self.num_completed_collection_phases = 0
 
     def buildProtocol(self, addr):
+        '''
+        Called by twisted
+        '''
         return PrivCountServerProtocol(self)
 
     def startFactory(self):
+        '''
+        Called by twisted
+        '''
         # TODO
         return
-        # load any state we may have from a previous run
-        state_filepath = normalise_path(self.config['state'])
-        if os.path.exists(state_filepath):
-            with open(state_filepath, 'r') as fin:
-                state = pickle.load(fin)
-                self.clients = state['clients']
-                self.collection_phase = state['collection_phase']
-                self.idle_time = state['idle_time']
+        state = self.load_state()
+        if state is not None:
+            self.clients = state['clients']
+            self.collection_phase = state['collection_phase']
+            self.idle_time = state['idle_time']
 
     def stopFactory(self):
         # TODO
         return
-        state_filepath = normalise_path(self.config['state'])
         if self.collection_phase is not None or len(self.clients) > 0:
             # export everything that would be needed to survive an app restart
             state = {'clients': self.clients, 'collection_phase': self.collection_phase, 'idle_time': self.idle_time}
-            with open(state_filepath, 'w') as fout:
-                pickle.dump(state, fout)
+            self.dump_state(state)
 
     def run(self):
+        '''
+        Called by twisted
+        '''
         # load initial config
         self.refresh_config()
         if self.config is None:
+            logging.critical("cannot start due to error in config file")
             return
 
         # refresh and check status every event_period seconds
@@ -146,6 +123,7 @@ class TallyServer(ServerFactory, PrivCountNode):
         '''
         re-read config and process any changes
         '''
+        # TODO: refactor common code: see ticket #121
         try:
             logging.debug("reading config file from '%s'", self.config_filepath)
 

--- a/privcount/util.py
+++ b/privcount/util.py
@@ -1216,6 +1216,35 @@ class SecureCounters(object):
         self.counters = None
         return counts
 
+class PrivCountNode(object):
+    '''
+    A mixin class that hosts common functionality for PrivCount client and
+    server factories: TallyServer, ShareKeeper, and DataCollector.
+    '''
+
+    def get_secret_handshake_path(self):
+        '''
+        Return the path of the secret handshake key file, or None if the config
+        has not been loaded.
+        Called by the protocol after a connection is opened.
+        '''
+        # The config must have been loaded by this point:
+        # - the server reads the config before opening a listener port
+        # - the clients read the config before opening a connection
+        assert self.config
+        # The secret handshake path should be loaded (or assigned a default)
+        # whenever the config is loaded
+        return self.config['secret_handshake']
+
+class PrivCountClient(PrivCountNode):
+    '''
+    A mixin class that hosts common functionality for PrivCount client
+    factories: ShareKeeper and DataCollector.
+    (There is no equivalent server class, as TallyServer is the only PrivCount
+    server class.)
+    '''
+    pass
+
 """
 def prob_exit(consensus_path, my_fingerprint, fingerprint_pool=None):
     '''

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -32,6 +32,12 @@ tally_server:
     key: 'keys/ts.pem' # path to the rsa private key
     cert: 'keys/ts.cert' # path to the public key certificate
     #results: './' # path to directory where the result files will be written
+    #
+    # the security of each PrivCount deployment depends on the handshake key
+    # being unique, random, and secret
+    # all nodes must agree on this key to handshake correctly
+    # if the key file does not exist, the TS creates a file with a random key
+    secret_handshake: 'keys/secret_handshake.yaml'
 
 # only the share keepers need these
 share_keeper:
@@ -41,6 +47,8 @@ share_keeper:
         port: 20001
     # optional overrides:
     key: 'keys/sk.pem' # path to the rsa private key
+    # all nodes must agree on this key to handshake correctly
+    secret_handshake: 'keys/secret_handshake.yaml'
 
 # only the data collectors need these
 data_collector:
@@ -52,3 +60,5 @@ data_collector:
         port: 20001
     share_keepers: # share keepers' public key hashes (`openssl rsa -pubout < keys/sk.pem | sha256sum`)
         - 'e79ea9173e28e6a54f6d2ec6494c1723a330811652acebbe8d98098ce347d679'
+    # all nodes must agree on this key to handshake correctly
+    secret_handshake: 'keys/secret_handshake.yaml'


### PR DESCRIPTION
PrivCount uses a HMAC-SHA256-based handshake to verify that client and server both know a shared secret key, without revealing the key on the wire.

While a HMAC is a proven cryptographic primitive, this particular construction has not been reviewed by a cryptographer, nor has this particular implementation undergone cryptographic review. It likely contains at least one bug, and any bugs might affect security.

See #117 for my notes about the protocol handshake design, and an example handshake run.
See 	62a09db for documentation on the keys created by PrivCount, including the secret handshake key.