### PR TITLE
SKs enforce a delay when the noise allocation changes

### DIFF
--- a/privcount/data_collector.py
+++ b/privcount/data_collector.py
@@ -228,6 +228,7 @@ class DataCollector(ReconnectingClientFactory, PrivCountClient):
             # (if not, we use the value of the collect period from the TS)
             assert dc_conf.get('delay_period', 1) > 0
 
+            dc_conf.setdefault('always_delay', False)
             assert isinstance(dc_conf['always_delay'], bool)
 
             dc_conf['sigma_decrease_tolerance'] = \

--- a/privcount/share_keeper.py
+++ b/privcount/share_keeper.py
@@ -208,6 +208,7 @@ class ShareKeeper(ReconnectingClientFactory, PrivCountClient):
             # (if not, we use the value of the collect period from the TS)
             assert sk_conf.get('delay_period', 1) > 0
 
+            sk_conf.setdefault('always_delay', False)
             assert isinstance(sk_conf['always_delay'], bool)
 
             sk_conf['sigma_decrease_tolerance'] = \

--- a/privcount/statistics_noise.py
+++ b/privcount/statistics_noise.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import scipy.stats
 import yaml
@@ -225,6 +226,13 @@ def get_opt_privacy_allocation(epsilon, delta, stats_parameters,
     opt_sigmas = dict()
     for param, (sensitivity, val) in stats_parameters.iteritems():
         opt_sigma = get_sigma(excess_noise_ratio, opt_sigma_ratio, val)
+        # Check if the sigma is too small
+        if opt_sigma == 0.0:
+            pass
+        elif opt_sigma < DEFAULT_SIGMA_TOLERANCE:
+            logging.warning("sigma {} for {} is less than the sigma tolerance {}, the calculated value may be inaccurate and may vary each time it is calculated"
+                            .format(opt_sigma, param, sigma_tol))
+
         opt_sigmas[param] = opt_sigma
 
     return (opt_epsilons, opt_sigmas, opt_sigma_ratio)

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -121,7 +121,8 @@ class TallyServer(ServerFactory, PrivCountServer):
                     if self.collection_delay.round_start_permitted(
                                                  self.config['noise'],
                                                  time(),
-                                                 self.config['delay_period']):
+                                                 self.config['delay_period'],
+                                                 self.config['always_delay']):
                         # we've passed all the checks, start the collection
                         num_phases = self.num_completed_collection_phases
                         logging.info("starting collection phase {} with {} DataCollectors and {} ShareKeepers".format((num_phases+1), len(dcs), len(sks)))
@@ -302,6 +303,8 @@ class TallyServer(ServerFactory, PrivCountServer):
                                 delay_min)
                 ts_conf['delay_period'] = delay_min
 
+            assert isinstance(ts_conf['always_delay'], bool)
+
             assert ts_conf['listen_port'] > 0
             assert ts_conf['sk_threshold'] > 0
             assert ts_conf['dc_threshold'] > 0
@@ -415,7 +418,8 @@ class TallyServer(ServerFactory, PrivCountServer):
             'continue' : self.config['continue'],
             'delay_until' : self.collection_delay.get_next_round_start_time(
                 self.config['noise'],
-                self.config['delay_period'])
+                self.config['delay_period'],
+                self.config['always_delay'])
         }
 
         # we can't know the expected end time until we have started
@@ -524,6 +528,7 @@ class TallyServer(ServerFactory, PrivCountServer):
             self.num_completed_collection_phases += 1
             self.collection_phase.write_results(self.config['results'])
             self.collection_delay.set_stop_result(
+                not self.collection_phase.is_error(),
                 # we can't use config['noise'], because it might have changed
                 # since the start of the round
                 self.collection_phase.get_noise_config(),
@@ -532,8 +537,7 @@ class TallyServer(ServerFactory, PrivCountServer):
                 # if config['delay_period'] has changed, we use it, and warn
                 # if it would have made a difference
                 self.config['delay_period'],
-                not self.collection_phase.is_error()
-                )
+                self.config['always_delay'])
             self.collection_phase = None
             self.idle_time = time()
 

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -931,9 +931,19 @@ class CollectionPhase(object):
             result_context['TallyServer']['Config']['key'] = "(key path)"
         if 'state' in result_context['TallyServer']['Config']:
             result_context['TallyServer']['Config']['state'] = "(state path)"
+        if 'secret_handshake' in result_context['TallyServer']['Config']:
+            result_context['TallyServer']['Config']['secret_handshake'] = \
+                "(secret_handshake path)"
+        if 'allocation' in result_context['TallyServer']['Config']:
+            result_context['TallyServer']['Config']['allocation'] = \
+                "(allocation path)"
+        if 'results' in result_context['TallyServer']['Config']:
+            result_context['TallyServer']['Config']['results'] = \
+                "(results path)"
         # And we don't need the bins, they're duplicated in 'Tally'
         if 'counters' in result_context['TallyServer']['Config']:
-            result_context['TallyServer']['Config']['counters'] = "(counters, no counts)"
+            result_context['TallyServer']['Config']['counters'] = "(counter bins, no counts)"
+        # but we want the noise, because it's not in Tally
 
         return result_context
 

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -298,6 +298,7 @@ class TallyServer(ServerFactory, PrivCountServer):
                 ts_conf['collect_period']
                 )
 
+            ts_conf.setdefault('always_delay', False)
             assert isinstance(ts_conf['always_delay'], bool)
 
             ts_conf['sigma_decrease_tolerance'] = \

--- a/privcount/util.py
+++ b/privcount/util.py
@@ -1818,10 +1818,10 @@ class PrivCountServer(PrivCountNode):
         # (if we use hard-coded sigmas, calculation accuracy is not
         # an issue - skip this check)
         if 'sigma_tolerance' in conf['noise'].get('privacy',{}):
-            assert (conf['sigma_decrease_tolerance'] >=
+            assert (tolerance >=
                     conf['noise']['privacy']['sigma_tolerance'])
         elif 'privacy' in conf['noise']:
-            assert (conf['sigma_decrease_tolerance'] >=
+            assert (tolerance >=
                     DEFAULT_SIGMA_TOLERANCE)
         else:
             # no extra checks

--- a/privcount/util.py
+++ b/privcount/util.py
@@ -1954,6 +1954,10 @@ class PrivCountClient(PrivCountNode):
         if self.start_config is not None:
             response['Config']['Start'] = self.start_config
 
+        # and include the config sent by the tally server to stop
+        if stop_config is not None:
+            response['Config']['Stop'] = stop_config
+
         # if we never started, there's no point in registering end of round
         if (self.collect_period is None or
             self.delay_period is None or
@@ -1975,6 +1979,12 @@ class PrivCountClient(PrivCountNode):
         # - the TS collect period and the config at start time, and
         # - the actual collect period and the current config.
         delay = max(self.delay_period, actual_delay)
+
+        # add this info to the context
+        response['Config']['Time'] = {}
+        response['Config']['Time']['Start'] = self.collection_start_time
+        response['Config']['Time']['Stop'] = end_time
+        response['Config']['Time']['Delay'] = actual_delay
 
         # Register the stop with the collection delay
         self.collection_delay.set_stop_result(

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -28,6 +28,7 @@ tally_server:
     # period, unless you are willing to wait a while for client status updates
     checkin_period: 2 # (default: 60 seconds) number of seconds clients should wait before checking with TS for updates
     delay_period: 4 # (default: collect_period) the number of seconds the TS should wait between rounds that change noise allocations
+    always_delay: True # (default: False) always enforce the delay period between collection rounds, regardless of whether the noise allocation has changed. Intended for use when testing.
     continue: 2 # start another collection phase after finishing a previous collection phase. If this value is an integer, run that many rounds before stopping. (The TS always runs at least 1 round.)
     # optional overrides:
     key: 'keys/ts.pem' # path to the rsa private key

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -20,14 +20,15 @@ tally_server:
     dc_threshold: 1 # number of data collector nodes required before starting
     # The elapsed test time is approximately:
     #     collect_period + 2*event_period
-    collect_period: 30 # (no default, 1 week = 604800 seconds) the safe time frame of stats collection for all stats
+    collect_period: 4 # (no default, 1 week = 604800 seconds) the safe time frame of stats collection for all stats
     # There must be at least two event periods in each collect period
-    event_period: 15 # (default: 60 seconds) how often the TS event loop runs
+    event_period: 2 # (default: 60 seconds) how often the TS event loop runs
     # There must be at least two checkin periods in each collect period
     # The checking period should also be less than or equal to the event
     # period, unless you are willing to wait a while for client status updates
-    checkin_period: 5 # (default: 60 seconds) number of seconds clients should wait before checking with TS for updates
-    continue: False # start another collection phase after finishing a previous
+    checkin_period: 2 # (default: 60 seconds) number of seconds clients should wait before checking with TS for updates
+    delay_period: 4 # (default: collect_period) the number of seconds the TS should wait between rounds that change noise allocations
+    continue: 2 # start another collection phase after finishing a previous collection phase. If this value is an integer, run that many rounds before stopping. (The TS always runs at least 1 round.)
     # optional overrides:
     key: 'keys/ts.pem' # path to the rsa private key
     cert: 'keys/ts.cert' # path to the public key certificate

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -50,6 +50,9 @@ share_keeper:
         port: 20001
     # optional overrides:
     key: 'keys/sk.pem' # path to the rsa private key
+    delay_period: 4 # (default: the previous round's collect_period from the tally server) the number of seconds of enforced delay between rounds that change noise allocations
+    always_delay: True # (default: False) always enforce the delay period between collection rounds, regardless of whether the noise allocation has changed. Intended for use when testing.
+    sigma_decrease_tolerance: 1.0e-6 # (default: 1.0e-6) the sigma value decrease that the node will tolerate before enforcing a delay
     # all nodes must agree on this key to handshake correctly
     secret_handshake: 'keys/secret_handshake.yaml'
 
@@ -63,5 +66,9 @@ data_collector:
         port: 20001
     share_keepers: # share keepers' public key hashes (`openssl rsa -pubout < keys/sk.pem | sha256sum`)
         - 'e79ea9173e28e6a54f6d2ec6494c1723a330811652acebbe8d98098ce347d679'
+    # optional overrides:
+    delay_period: 4 # (default: the previous round's collect_period from the tally server) the number of seconds of enforced delay between rounds that change noise allocations
+    always_delay: True # (default: False) always enforce the delay period between collection rounds, regardless of whether the noise allocation has changed. Intended for use when testing.
+    sigma_decrease_tolerance: 1.0e-6 # (default: 1.0e-6) the sigma value decrease that the node will tolerate before enforcing a delay
     # all nodes must agree on this key to handshake correctly
     secret_handshake: 'keys/secret_handshake.yaml'

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -29,7 +29,7 @@ tally_server:
     checkin_period: 2 # (default: 60 seconds) number of seconds clients should wait before checking with TS for updates
     delay_period: 4 # (default: collect_period) the number of seconds of enforced delay between rounds that change noise allocations
     always_delay: True # (default: False) always enforce the delay period between collection rounds, regardless of whether the noise allocation has changed. Intended for use when testing.
-    sigma_decrease_tolerance: 1.0e-6 # (default: 1.0e-6) the sigma value decrease that the node will tolerate before enforcing a delay
+    #sigma_decrease_tolerance: 1.0e-6 # (default: 1.0e-6) the sigma value decrease that the node will tolerate before enforcing a delay
     continue: 2 # start another collection phase after finishing a previous collection phase. If this value is an integer, run that many rounds before stopping. (The TS always runs at least 1 round.)
     # optional overrides:
     key: 'keys/ts.pem' # path to the rsa private key
@@ -50,7 +50,7 @@ share_keeper:
         port: 20001
     # optional overrides:
     key: 'keys/sk.pem' # path to the rsa private key
-    delay_period: 4 # (default: the previous round's collect_period from the tally server) the number of seconds of enforced delay between rounds that change noise allocations
+    delay_period: 6 # (default: the previous round's collect_period from the tally server) the number of seconds of enforced delay between rounds that change noise allocations
     always_delay: True # (default: False) always enforce the delay period between collection rounds, regardless of whether the noise allocation has changed. Intended for use when testing.
     sigma_decrease_tolerance: 1.0e-6 # (default: 1.0e-6) the sigma value decrease that the node will tolerate before enforcing a delay
     # all nodes must agree on this key to handshake correctly
@@ -67,8 +67,8 @@ data_collector:
     share_keepers: # share keepers' public key hashes (`openssl rsa -pubout < keys/sk.pem | sha256sum`)
         - 'e79ea9173e28e6a54f6d2ec6494c1723a330811652acebbe8d98098ce347d679'
     # optional overrides:
-    delay_period: 4 # (default: the previous round's collect_period from the tally server) the number of seconds of enforced delay between rounds that change noise allocations
-    always_delay: True # (default: False) always enforce the delay period between collection rounds, regardless of whether the noise allocation has changed. Intended for use when testing.
-    sigma_decrease_tolerance: 1.0e-6 # (default: 1.0e-6) the sigma value decrease that the node will tolerate before enforcing a delay
+    #delay_period: 4 # (default: the previous round's collect_period from the tally server) the number of seconds of enforced delay between rounds that change noise allocations
+    #always_delay: True # (default: False) always enforce the delay period between collection rounds, regardless of whether the noise allocation has changed. Intended for use when testing.
+    #sigma_decrease_tolerance: 1.0e-6 # (default: 1.0e-6) the sigma value decrease that the node will tolerate before enforcing a delay
     # all nodes must agree on this key to handshake correctly
     secret_handshake: 'keys/secret_handshake.yaml'

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -27,8 +27,9 @@ tally_server:
     # The checking period should also be less than or equal to the event
     # period, unless you are willing to wait a while for client status updates
     checkin_period: 2 # (default: 60 seconds) number of seconds clients should wait before checking with TS for updates
-    delay_period: 4 # (default: collect_period) the number of seconds the TS should wait between rounds that change noise allocations
+    delay_period: 4 # (default: collect_period) the number of seconds of enforced delay between rounds that change noise allocations
     always_delay: True # (default: False) always enforce the delay period between collection rounds, regardless of whether the noise allocation has changed. Intended for use when testing.
+    sigma_decrease_tolerance: 1.0e-6 # (default: 1.0e-6) the sigma value decrease that the node will tolerate before enforcing a delay
     continue: 2 # start another collection phase after finishing a previous collection phase. If this value is an integer, run that many rounds before stopping. (The TS always runs at least 1 round.)
     # optional overrides:
     key: 'keys/ts.pem' # path to the rsa private key

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -150,7 +150,7 @@ if [ -e privcount.outcome.latest.json -a \
   # events falling before or after data collection stops in short runs
   diff --minimal \
       -I "time" -I "[Cc]lock" -I "alive" -I "rtt" -I "Start" -I "Stop" \
-      -I "delay" \
+      -I "[Dd]elay" \
       old/privcount.outcome.latest.json privcount.outcome.latest.json || true
 else
   # Since we need old/latest and latest, it takes two runs to generate the

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -150,6 +150,7 @@ if [ -e privcount.outcome.latest.json -a \
   # events falling before or after data collection stops in short runs
   diff --minimal \
       -I "time" -I "[Cc]lock" -I "alive" -I "rtt" -I "Start" -I "Stop" \
+      -I "delay" \
       old/privcount.outcome.latest.json privcount.outcome.latest.json || true
 else
   # Since we need old/latest and latest, it takes two runs to generate the


### PR DESCRIPTION
The TS checks is own delay settings before starting a round, and reports any delay in its status.
DCs can also optionally enforce a delay when the noise allocation changes.

See the individual commit messages for details