### PR TITLE
Control socket

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -71,7 +71,7 @@ If the encryption unit tests fail with an "UnsupportedAlgorithm" exception, make
 To run PrivCount, simply activate the virtual environment that you created earlier and then run PrivCount as normal. For example:
 
     source venv/bin/activate # enter the virtual environment
-    test/test_tor_ctl_event.py <CONTROL_PORT> # test privcount events
+    test/test_tor_ctl_event.py <control-port-or-path> # test privcount events
     privcount --help
     ...
     deactivate # exit the virtual environment

--- a/privcount/__init__.py
+++ b/privcount/__init__.py
@@ -1,5 +1,6 @@
 __all__ = [
    'config',
+   'connection',
    'counter',
    'crypto',
    'data_collector',

--- a/privcount/__init__.py
+++ b/privcount/__init__.py
@@ -1,4 +1,5 @@
 __all__ = [
+   'config',
    'counter',
    'crypto',
    'data_collector',
@@ -9,5 +10,4 @@ __all__ = [
    'share_keeper',
    'statistics_noise',
    'tally_server',
-   'util',
 ]

--- a/privcount/config.py
+++ b/privcount/config.py
@@ -1,31 +1,12 @@
 '''
-Created on Dec 15, 2015
+Created on Dec 8, 2016
 
-@author: rob
+@author: teor
+
+Based on previous code
 '''
 
-# This module is for miscellaneous functions
-# When a section grows large enough, move it to its own module
-
-import socket
-
 from os import path
-
-from privcount.counter import sample_randint
-
-## Networking ##
-
-def get_random_free_port():
-    while True:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        # choose an evenly distributed port that doesn't leak RNG state
-        port = sample_randint(10000, 60000)
-        rc = s.connect_ex(('127.0.0.1', port))
-        s.close()
-        if rc != 0: # error connecting, port is available
-            return port
-
-## File Paths / Config ##
 
 def normalise_path(path_str):
     '''

--- a/privcount/connection.py
+++ b/privcount/connection.py
@@ -1,0 +1,273 @@
+'''
+Created on Dec 8, 2016
+
+@author: teor
+'''
+
+from collections import Sequence
+from exceptions import AttributeError
+
+from twisted.internet import reactor
+
+# Function abstractions for building connections
+# Like connectionFromString, but using the reactor model (to avoid a complete
+# redesign using endpoints)
+# https://twistedmatrix.com/documents/current/core/howto/endpoints.html
+
+# The default listener addresses for each IP version
+# These depend on whether we are listening on the loopback interface or not
+IP_LISTEN_DEFAULT = {
+    4 : { True : '127.0.0.1', False : '0.0.0.0' },
+    6 : { True : '::1',       False : '::' }
+}
+
+# The default connector addresses for each IP version
+# These only make sense if we are connecting to the loopback interface
+IP_CONNECT_DEFAULT = {
+    4 : '127.0.0.1',
+    6 : '::1'
+}
+
+def listen(factory, config, ip_local_default=True, ip_version_default=4):
+    '''
+    Set up factory to listen for connections, based on config, which is a
+    dictionary containing listening configuration information.
+    IP addresses:
+      port: IP port
+      interface: IPv4 or IPv6 address (optional)
+    UNIX sockets:
+      unix: Unix socket path
+    If there is a port, but no interface:
+    - if ip_local_default is True, IP listeners listen on localhost, otherwise
+    - if it is False, they listen on all interfaces, and
+    - ip_version_default is the IP version they listen on.
+    The default is to listen on IPv4 localhost, to avoid opening unexpected
+    public ports.
+    Returns a listener object.
+    
+    config and ip_version_default also accept lists of configs and IP versions.
+    (And config accepts an IP and unix config in the same dictionary.)
+    This can be hard to debug, because it easily produces duplicate
+    connections between the same pair of factories.
+    (To avoid these issues, the IP defaults open a single listener on
+    localhost.)
+    When there are multiple configs, the return value is a list containing
+    one listener per listening config. For each config that uses IP version
+    defaults, there will be one listener per IP version.
+    '''
+    # upgrade things to lists if they have been passed as single items
+    config = _listify(config)
+    ip_version_default = _listify(ip_version_default)
+    # now process the lists
+    listeners = []
+    # the order of the two functions below is irrelevant: all listeners have
+    # equal priority regardless of order of creation
+    listeners.extend(_listify(listen_unix(factory, config)))
+    listeners.extend(_listify(listen_ip(factory, config,
+                               ip_local_default, ip_version_default)))
+    return _unlistify(listeners)
+
+def listen_unix(factory, config):
+    '''
+    Internal implementation that opens unix socket listeners for factory based
+    on config. See listen() for details.
+    '''
+    # upgrade config to a list if it has been passed as a single item
+    config = _listify(config)
+    # now process the list
+    listeners = []
+    for item in config:
+        if 'unix' in item:
+            path = item['unix']
+            listeners.append(reactor.listenUNIX(path, factory))
+    return _unlistify(listeners)
+
+def listen_ip(factory, config, ip_local_default=True, ip_version_default=4):
+    '''
+    Internal implementation that opens IP listeners for factory based on
+    config. See listen() for details.
+    '''
+    # upgrade things to lists if they have been passed as single items
+    config = _listify(config)
+    ip_version_default = _listify(ip_version_default)
+    # now process the list
+    listeners = []
+    for item in config:
+        if 'port' in item:
+            port = int(item['port'])
+            if 'interface' in item:
+                interface = item['interface']
+                listeners.append(reactor.listenTCP(port, factory,
+                                                   interface=interface))
+            else:
+                for ip_version in ip_version_default:
+                    interface = IP_LISTEN_DEFAULT[ip_version][ip_local_default]
+                    listeners.append(reactor.listenTCP(port, factory,
+                                                       interface=interface))
+    return _unlistify(listeners)
+
+def connect(factory, config, ip_local_default=True, ip_version_default=4):
+    '''
+    Set up factory to connect to service, based on config, which is a
+    dictionary containing connection configuration information.
+    Known config keys are:
+    IP addresses:
+      port: IP port
+      interface: IPv4 or IPv6 address (optional)
+    UNIX sockets:
+      unix: Unix socket path
+    If there is a port, but no interface:
+    - if ip_local_default is True, IP connections connect to localhost on
+      IP version ip_version_default.
+    - if ip_local_default is False, IP connections must have an interface
+      address.
+    The default is to try IPv4 localhost.
+    Returns a connector object.
+
+    config and ip_version_default also accept lists of configs and IP versions.
+    (And config accepts an IP and unix config in the same dictionary.)
+    This can be hard to debug, because it easily produces duplicate
+    connections between the same pair of factories. In addition, the protocol
+    object only stores the last connection opened as the transport, and so all
+    events are attributed to that transport, regardless of actual origin.
+    (To avoid these issues, the IP defaults open a single connection to
+    localhost.)
+    When there are multiple connections, the return value is a list of
+    connector objects, one per connection config. For each config that uses
+    IP version defaults, there will be one connector per IP version.
+    '''
+    # upgrade things to lists if they have been declared as single items
+    config = _listify(config)
+    ip_version_default = _listify(ip_version_default)
+    # now process the lists
+    connectors = []
+    # the first connection succeeds and is used by the factory
+    # prioritise unix sockets over IP ports, the filesystem is typically more
+    # secure
+    connectors.extend(_listify(connect_unix(factory, config)))
+    connectors.extend(_listify(connect_ip(factory, config,
+                                ip_local_default, ip_version_default)))
+    return _unlistify(connectors)
+
+def connect_unix(factory, config):
+    '''
+    Internal implementation that opens unix socket connections for factory
+    based on config. See connect() for details.
+    '''
+    # upgrade config to a list if it has been passed as a single item
+    config = _listify(config)
+    # now process the list
+    connectors = []
+    for item in config:
+        if 'unix' in item:
+            path = item['unix']
+            connectors.append(reactor.connectUNIX(path, factory))
+    return _unlistify(connectors)
+
+def connect_ip(factory, config, ip_local_default=True, ip_version_default=4):
+    '''
+    Internal implementation that opens IP connections for factory based on
+    config. See connect() for details.
+    '''
+    # upgrade things to lists if they have been passed as single items
+    config = _listify(config)
+    ip_version_default = _listify(ip_version_default)
+    # now process the list
+    connectors = []
+    for item in config:
+        if 'port' in item:
+            port = int(item['port'])
+            if 'interface' in item:
+                interface = item['interface']
+                connectors.append(reactor.connectTCP(interface, port, factory))
+            elif ip_local_default:
+                for ip_version in ip_version_default:
+                    interface = IP_CONNECT_DEFAULT[ip_version]
+                    connectors.append(reactor.connectTCP(interface, port,
+                                                         factory))
+    return _unlistify(connectors)
+
+def _listify(arg):
+    '''
+    If arg is not a sequence, return it in a one-item list.
+    Otherwise, return it unmodified.
+    '''
+    if not isinstance(arg, (Sequence)):
+        return [arg]
+    else:
+        return arg
+
+def _unlistify(arg):
+    '''
+    If arg is a sequence with one item, return that item.
+    Otherwise, return the list unmodified.
+    '''
+    if isinstance(arg, (Sequence)) and len(arg) == 1:
+        return arg[0]
+    else:
+        return arg
+
+def transport_info(transport):
+    '''
+    Return a string describing the remote peer and local endpoint connected
+    via transport
+    '''
+    host_str = transport_host(transport)
+    peer_str = transport_peer(transport)
+    if host_str is not None and peer_str is not None:
+        return "remote: {} local: {}".format(peer_str, host_str)
+    elif host_str is not None:
+        return host_str
+    elif peer_str is not None:
+        return peer_str
+    else:
+        return None
+
+def transport_peer(transport):
+    '''
+    Return a string describing the remote peer connected to transport
+    '''
+    peer = transport.getPeer()
+    return address_info(peer)
+
+def transport_host(transport):
+    '''
+    Return a string describing the local endpoint connected to transport
+    '''
+    try:
+        host = transport.getHost()
+    except AttributeError:
+        return None
+    if host is None:
+        return None
+    return address_info(host)
+
+def address_info(address):
+    '''
+    Return a string describing the address
+    '''
+    # Looks like an IPv4Address or IPv6Address
+    try:
+        # ignore type, it's always TCP
+        return "{}:{}".format(address.host, address.port)
+    except AttributeError:
+        pass
+    # Looks like a HostnameAddress
+    # (we don't yet support hostnames in connect and listen)
+    try:
+        return "{}:{}".format(address.hostname, address.port)
+    except AttributeError:
+        pass
+    # Looks like a UNIXAddress
+    try:
+        # Handle host for UNIXAddress, which is always None
+        if address.name is None:
+            return None
+        else:
+            return "{}".format(address.name)
+    except AttributeError:
+        pass
+    if address is None:
+        return None
+    # Just ask it how it wants to be represented
+    return str(address)

--- a/privcount/crypto.py
+++ b/privcount/crypto.py
@@ -221,8 +221,7 @@ def decrypt_pk(priv_key, ciphertext):
     Decrypt a b64encoded ciphertext string with the RSA private key priv_key,
     using CryptoHash() as the OAEP/MGF1 padding hash.
     Returns the plaintext.
-    Fails and calls os._exit on an UnsupportedAlgorithm exception.
-    (Other decryption failures result in an exception being raised.)
+    Decryption failures result in an exception being raised.
     """
     try:
         plaintext = priv_key.decrypt(

--- a/privcount/data_collector.py
+++ b/privcount/data_collector.py
@@ -13,6 +13,7 @@ from twisted.internet import task, reactor, ssl
 from twisted.internet.protocol import ReconnectingClientFactory
 
 from privcount.config import normalise_path, choose_secret_handshake_path
+from privcount.connection import connect
 from privcount.counter import SecureCounters, counter_modulus, add_counter_limits_to_config, combine_counters
 from privcount.crypto import get_public_digest_string, load_public_key_string, encrypt
 from privcount.log import log_error, format_delay_time_wait, format_last_event_time_since
@@ -319,7 +320,13 @@ class Aggregator(ReconnectingClientFactory):
         return
 
     def start(self):
-        self.connector = reactor.connectTCP("127.0.0.1", self.tor_control_port, self)
+        '''
+        start the aggregator, and connect to the control port
+        '''
+        self.connector = connect(self,
+                                 { 'port' : self.tor_control_port }
+                                 #{ 'unix' : '/var/run/tor/control' }
+                                 )
         self.rotator = task.LoopingCall(self._do_rotate).start(600, now=False)
         self.cli_ips_rotated = time()
         # if we've already built the protocol before starting

--- a/privcount/data_collector.py
+++ b/privcount/data_collector.py
@@ -12,12 +12,12 @@ from base64 import b64decode
 from twisted.internet import task, reactor, ssl
 from twisted.internet.protocol import ReconnectingClientFactory
 
+from privcount.config import normalise_path, choose_secret_handshake_path
 from privcount.counter import SecureCounters, counter_modulus, add_counter_limits_to_config, combine_counters
 from privcount.crypto import get_public_digest_string, load_public_key_string, encrypt
 from privcount.log import log_error, format_delay_time_wait, format_last_event_time_since
 from privcount.node import PrivCountClient
 from privcount.protocol import PrivCountClientProtocol, TorControlClientProtocol
-from privcount.util import normalise_path, choose_secret_handshake_path
 
 # using reactor: pylint: disable=E1101
 # method docstring missing: pylint: disable=C0111

--- a/privcount/inject.py
+++ b/privcount/inject.py
@@ -13,8 +13,8 @@ from twisted.internet import reactor
 from twisted.internet.protocol import ServerFactory
 from twisted.internet.error import ReactorNotRunning
 
+from privcount.config import normalise_path
 from privcount.protocol import TorControlServerProtocol
-from privcount.util import normalise_path
 
 listener = None
 

--- a/privcount/inject.py
+++ b/privcount/inject.py
@@ -17,6 +17,8 @@ from privcount.config import normalise_path
 from privcount.connection import listen
 from privcount.protocol import TorControlServerProtocol
 
+DEFAULT_PRIVCOUNT_INJECT_SOCKET = '/tmp/privcount-inject'
+
 listener = None
 
 class PrivCountDataInjector(ServerFactory):
@@ -159,18 +161,42 @@ def run_inject(args):
     # injects events into the first client to connect
     # Since these are synthetic events, it is safe to use /tmp for the socket
     # path
-    listeners = listen(injector,
-                       [ { 'port' : int(args.port) },
-                         { 'unix' : '/tmp/privcount-inject' } ],
-                       ip_version_default = [4, 6])
+    # XXX multiple connections to our server will kill old connections
+    listener_config = {}
+    if args.port is not None:
+        listener_config['port'] = args.port
+        if args.ip is not None:
+            listener_config['ip'] = args.ip
+    if args.unix is not None:
+        listener_config['unix']= args.unix
+    listeners = listen(injector, listener_config, ip_version_default = [4, 6])
     reactor.run()
 
 def add_inject_args(parser):
-    parser.add_argument('-p', '--port', help="port on which to listen for PrivCount connections", required=True)
-    parser.add_argument('-l', '--log', help="a file PATH to a PrivCount event log file, may be '-' for STDIN", required=True, default='-')
-    parser.add_argument('-s', '--simulate', action='store_true', help="add pauses between each event injection to simulate the inter-arrival times from the source data")
-    parser.add_argument('--prune-before', help="do not inject events that occurred before the given unix timestamp", default=0)
-    parser.add_argument('--prune-after', help="do not inject events that occurred after the given unix timestamp", default=2147483647)
+    parser.add_argument('-p', '--port',
+                        help="port on which to listen for PrivCount connections(default: no IP listener)",
+                        required=False)
+    parser.add_argument('-i', '--ip',
+                        help="IPv4 or IPv6 address on which to listen for PrivCount connections (default: both 127.0.0.1 and ::1)",
+                        required=False)
+    parser.add_argument('-u', '--unix',
+                        help="Unix socket on which to listen for PrivCount connections (default: '{}')"
+                        .format(DEFAULT_PRIVCOUNT_INJECT_SOCKET),
+                        required=False,
+                        default=DEFAULT_PRIVCOUNT_INJECT_SOCKET)
+    parser.add_argument('-l', '--log',
+                        help="a file PATH to a PrivCount event log file, may be '-' for STDIN (default: STDIN)",
+                        required=True,
+                        default='-')
+    parser.add_argument('-s', '--simulate',
+                        action='store_true',
+                        help="add pauses between each event injection to simulate the inter-arrival times from the source data")
+    parser.add_argument('--prune-before',
+                        help="do not inject events that occurred before the given unix timestamp",
+                        default=0)
+    parser.add_argument('--prune-after',
+                        help="do not inject events that occurred after the given unix timestamp",
+                        default=2147483647)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/privcount/inject.py
+++ b/privcount/inject.py
@@ -190,7 +190,8 @@ def add_inject_args(parser):
                         default='-')
     parser.add_argument('-s', '--simulate',
                         action='store_true',
-                        help="add pauses between each event injection to simulate the inter-arrival times from the source data")
+                        help="add pauses between each event injection to simulate the inter-arrival times from the source data",
+                        default=True)
     parser.add_argument('--prune-before',
                         help="do not inject events that occurred before the given unix timestamp",
                         default=0)

--- a/privcount/node.py
+++ b/privcount/node.py
@@ -8,10 +8,10 @@ import logging
 
 from time import time
 
+from privcount.config import normalise_path
 from privcount.counter import check_counters_config, check_noise_weight_config, combine_counters, CollectionDelay, float_accuracy, add_counter_limits_to_config
 from privcount.log import format_delay_time_until, format_elapsed_time_since
 from privcount.statistics_noise import DEFAULT_SIGMA_TOLERANCE
-from privcount.util import normalise_path
 
 def get_remaining_rounds(num_phases, continue_config):
         '''

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -1,7 +1,7 @@
 import logging, json, math
 
 from time import time
-from os import _exit, urandom, path
+from os import urandom, path
 from base64 import b64encode, b64decode
 
 from twisted.internet import reactor
@@ -47,15 +47,7 @@ class PrivCountProtocol(LineOnlyReceiver):
             logging.error(
                 "Exception {} while initialising PrivCountProtocol instance"
                 .format(e))
-            # die immediately using os._exit()
-            # we can't use sys.exit() here, because twisted catches and logs it
-            _exit(1)
-        except:
-            # catch exceptions that don't derive from BaseException
-            logging.error(
-                "Unknown Exception while processing event type: {} payload: {}"
-                .format(event_type, event_payload))
-            _exit(1)
+            reactor.stop()
 
     def connectionMade(self): # overrides twisted function
         peer = self.transport.getPeer()
@@ -116,16 +108,7 @@ class PrivCountProtocol(LineOnlyReceiver):
             # bring down the privcount network.
             # Since we ignore unrecognised events, the client would have to be
             # maliciously crafted, not just a port scanner.
-
-            # die immediately using os._exit()
-            # we can't use sys.exit() here, because twisted catches and logs it
-            _exit(1)
-        except:
-            # catch exceptions that don't derive from BaseException
-            logging.error(
-                "Unknown Exception while processing event type: {} payload: {}"
-                .format(event_type, event_payload))
-            _exit(1)
+            reactor.stop()
 
         if not self.is_valid_connection:
             self.protocol_failed()

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -9,6 +9,7 @@ from twisted.protocols.basic import LineOnlyReceiver
 
 from cryptography.hazmat.primitives.hashes import SHA256
 
+from privcount.connection import transport_info, transport_peer, transport_host
 from privcount.counter import get_events_for_counters, get_valid_events
 from privcount.crypto import CryptoHash, get_hmac, verify_hmac, b64_padded_length
 
@@ -49,27 +50,39 @@ class PrivCountProtocol(LineOnlyReceiver):
                 .format(e))
             reactor.stop()
 
-    def connectionMade(self): # overrides twisted function
-        peer = self.transport.getPeer()
-        logging.debug("Connection with {}:{}:{} was made".format(peer.type, peer.host, peer.port))
+    def connectionMade(self):
+        '''
+        overrides twisted function
+        '''
+        logging.debug("Connection with {} was made"
+                      .format(transport_info(self.transport)))
 
-    def lineReceived(self, line): # overrides twisted function
-        peer = self.transport.getPeer()
-        logging.debug("Received line '{}' from {}:{}:{}".format(line, peer.type, peer.host, peer.port))
+    def lineReceived(self, line):
+        '''
+        overrides twisted function
+        '''
+        logging.debug("Received line '{}' from {}"
+                      .format(line, transport_info(self.transport)))
         parts = [part.strip() for part in line.split(' ', 1)]
         if len(parts) > 0:
             event_type = parts[0]
             event_payload = parts[1] if len(parts) > 1 else ''
             self.process_event(event_type, event_payload)
 
-    def sendLine(self, line): # overrides twisted function
-        peer = self.transport.getPeer()
-        logging.debug("Sending line '{}' to {}:{}:{}".format(line, peer.type, peer.host, peer.port))
+    def sendLine(self, line):
+        '''
+        overrides twisted function
+        '''
+        logging.debug("Sending line '{}' to {}"
+                      .format(line, transport_info(self.transport)))
         return LineOnlyReceiver.sendLine(self, line)
 
-    def lineLengthExceeded(self, line): # overrides twisted function
-        peer = self.transport.getPeer()
-        logging.warning("Incomming line of length {} exceeded MAX_LENGTH of {}, dropping unvalidated connection to {}:{}:{}".format(len(line), self.MAX_LENGTH, peer.type, peer.host, peer.port))
+    def lineLengthExceeded(self, line):
+        '''
+        overrides twisted function
+        '''
+        logging.warning("Incoming line of length {} exceeded MAX_LENGTH of {}, dropping unvalidated connection to {}"
+                        .format(len(line), transport_info(self.transport)))
         return LineOnlyReceiver.lineLengthExceeded(self, line)
 
     def process_event(self, event_type, event_payload):
@@ -648,31 +661,47 @@ class PrivCountProtocol(LineOnlyReceiver):
         return True
 
     def handshake_succeeded(self):
-        peer = self.transport.getPeer()
-        logging.debug("Handshake with {}:{}:{} was successful".format(peer.type, peer.host, peer.port))
+        '''
+        Called when the PrivCount handshake succeeds
+        '''
+        logging.debug("Handshake with {} was successful"
+                      .format(transport_info(self.transport)))
         self.is_valid_connection = True
         self.MAX_LENGTH = 512*1024 # now allow longer lines
 
     def handshake_failed(self):
-        peer = self.transport.getPeer()
-        logging.warning("Handshake with {}:{}:{} failed".format(peer.type, peer.host, peer.port))
+        '''
+        Called when the PrivCount handshake fails
+        '''
+        logging.warning("Handshake with {} failed"
+                        .format(transport_info(self.transport)))
         self.is_valid_connection = False
         self.transport.loseConnection()
 
     def protocol_succeeded(self):
-        peer = self.transport.getPeer()
-        logging.debug("Protocol with {}:{}:{} was successful".format(peer.type, peer.host, peer.port))
+        '''
+        Called when the protocol has finished successfully
+        '''
+        logging.debug("Protocol with {} was successful"
+                      .format(transport_info(self.transport)))
         self.transport.loseConnection()
 
     def protocol_failed(self):
-        peer = self.transport.getPeer()
-        logging.warning("Protocol with {}:{}:{} failed".format(peer.type, peer.host, peer.port))
+        '''
+        Called when the prococol finishes in failure
+        '''
+        logging.warning("Protocol with {} failed"
+                        .format(transport_info(self.transport)))
         self.is_valid_connection = False
         self.transport.loseConnection()
 
-    def connectionLost(self, reason): # overrides twisted function
-        peer = self.transport.getPeer()
-        logging.debug("Connection with {}:{}:{} was lost: {}".format(peer.type, peer.host, peer.port, reason.getErrorMessage()))
+    def connectionLost(self, reason):
+        '''
+        overrides twisted function
+        '''
+        logging.debug("Connection with {} was lost: {}"
+                      .format(transport_info(self.transport),
+                              reason.getErrorMessage()))
 
     def handle_handshake_event(self, event_type, event_payload):
         '''
@@ -771,7 +800,13 @@ class PrivCountServerProtocol(PrivCountProtocol):
             client_status = json.loads(parts[1])
 
             client_status['alive'] = time()
-            client_status['host'] = self.transport.getPeer().host
+            host = transport_host(self.transport)
+            if host is None:
+                host = '(unknown)'
+            client_status['host'] = host
+            peer = transport_peer(self.transport)
+            if peer is not None:
+                client_status['peer'] = peer
             client_status['clock_skew'] = 0.0
             client_status['rtt'] = 0.0
 
@@ -943,8 +978,8 @@ class TorControlClientProtocol(LineOnlyReceiver):
         the 'authenticating' state.
         Overrides twisted function.
         '''
-        peer = self.transport.getPeer()
-        logging.debug("Connection with {}:{}:{} was made".format(peer.type, peer.host, peer.port))
+        logging.debug("Connection with {} was made"
+                      .format(transport_info(self.transport)))
         # we must authenticate first, before doing anything else
         self.sendLine("AUTHENTICATE")
         self.state = 'authenticating'
@@ -965,7 +1000,7 @@ class TorControlClientProtocol(LineOnlyReceiver):
                     self.collection_events.add(upper_event)
                 else:
                     logging.warning("Ignored unknown event: {}".format(event))
-        logging.warning("Starting PrivCount collection with events: {} from counters: {} and events: {}"
+        logging.info("Starting PrivCount collection with events: {} from counters: {} and events: {}"
                         .format(" ".join(self.collection_events),
                                 "(none)" if counter_list is None else
                                 " ".join(counter_list),
@@ -1019,7 +1054,7 @@ class TorControlClientProtocol(LineOnlyReceiver):
             self.active_events = None
             self.state = 'waiting'
 
-    def setDiscoveredValue(self, function_name, value, value_name, peer):
+    def setDiscoveredValue(self, function_name, value, value_name):
         '''
         When we discover value from the relay, call set_function to set it,
         and log a message containing value_name if this fails.
@@ -1027,12 +1062,12 @@ class TorControlClientProtocol(LineOnlyReceiver):
         try:
             # Equivalent to self.factory.set_*(value)
             if not getattr(self.factory, function_name)(value):
-                logging.warning("Connection with {}:{}:{}: bad {}: {}"
-                                .format(peer.type, peer.host, peer.port,
+                logging.warning("Connection with {}: bad {}: {}"
+                                .format(transport_info(self.transport),
                                         value_name, value))
         except AttributeError as e:
-            logging.warning("Connection with {}:{}:{}: sent {}: {}, but factory raised {}"
-                            .format(peer.type, peer.host, peer.port,
+            logging.warning("Connection with {}: sent {}: {}, but factory raised {}"
+                            .format(transport_info(self.transport),
                                     value_name, value, e))
 
     def lineReceived(self, line):
@@ -1047,9 +1082,9 @@ class TorControlClientProtocol(LineOnlyReceiver):
         When events are received, process them.
         Overrides twisted function.
         '''
-        peer = self.transport.getPeer()
         line = line.strip()
-        logging.debug("Received line '{}' from {}:{}:{}".format(line, peer.type, peer.host, peer.port))
+        logging.debug("Received line '{}' from {}"
+                      .format(line, transport_info(self.transport)))
 
         if self.state == 'authenticating' and line == "250 OK":
             # Turn off privcount events, so we don't get spurious responses
@@ -1066,60 +1101,62 @@ class TorControlClientProtocol(LineOnlyReceiver):
             # -- These cases continue discovering, or quit() -- #
             # It doesn't have PrivCount
             if line.startswith("552 Unrecognized option"):
-                logging.critical("Connection with {}:{}:{}: does not support PrivCount".format(peer.type, peer.host, peer.port))
+                logging.critical("Connection with {}: does not support PrivCount"
+                                 .format(transport_info(self.transport)))
                 self.quit()
             # It's a relay, and it's just told us its Nickname
             elif line.startswith("250 Nickname="):
                 _, _, nickname = line.partition("Nickname=") # returns: part1, separator, part2
-                self.setDiscoveredValue('set_nickname', nickname, 'Nickname',
-                                        peer)
+                self.setDiscoveredValue('set_nickname', nickname, 'Nickname')
             # It doesn't have a Nickname, maybe it's a client?
             # But we'll catch that when we check the fingerprint, so just ignore this response
             elif line == "250 Nickname":
-                logging.info("Connection with {}:{}:{}: no Nickname".format(peer.type, peer.host, peer.port))
+                logging.info("Connection with {}: no Nickname"
+                             .format(transport_info(self.transport)))
             # It's a relay, and it's just told us its ORPort
             elif line.startswith("250 ORPort="):
                 _, _, orport = line.partition("ORPort=") # returns: part1, separator, part2
-                self.setDiscoveredValue('set_orport', orport, 'ORPort', peer)
+                self.setDiscoveredValue('set_orport', orport, 'ORPort')
             # It doesn't have an ORPort, maybe it's a client?
             # But we'll catch that when we check the fingerprint, so just ignore this response
             elif line == "250 ORPort":
-                logging.warning("Connection with {}:{}:{}: no ORPort".format(peer.type, peer.host, peer.port))
+                logging.warning("Connection with {}: no ORPort"
+                                .format(transport_info(self.transport)))
             # It's a relay, and it's just told us its DirPort
             elif line.startswith("250 DirPort="):
                 _, _, dirport = line.partition("DirPort=") # returns: part1, separator, part2
-                self.setDiscoveredValue('set_dirport', dirport, 'DirPort',
-                                        peer)
+                self.setDiscoveredValue('set_dirport', dirport, 'DirPort')
             elif line == "250 DirPort":
-                logging.info("Connection with {}:{}:{}: no DirPort".format(peer.type, peer.host, peer.port))
+                logging.info("Connection with {}: no DirPort"
+                             .format(transport_info(self.transport)))
             # It's just told us its version
             # The control spec assumes that Tor always has a version, so there's no error case
             elif line.startswith("250-version="):
                 _, _, version = line.partition("version=") # returns: part1, separator, part2
-                self.setDiscoveredValue('set_version', version, 'version',
-                                        peer)
+                self.setDiscoveredValue('set_version', version, 'version')
             # It's just told us its address
             elif line.startswith("250-address="):
                 _, _, address = line.partition("address=") # returns: part1, separator, part2
-                self.setDiscoveredValue('set_address', address, 'address',
-                                        peer)
+                self.setDiscoveredValue('set_address', address, 'address')
             # We asked for its address, and it couldn't find it. That's weird.
             elif line == "551 Address unknown":
-                logging.info("Connection with {}:{}:{}: does not know its own address".format(peer.type, peer.host, peer.port))
+                logging.info("Connection with {}: does not know its own address"
+                             .format(transport_info(self.transport)))
             # -- fingerprint discovery ends in waiting or quit() --
             # It's a relay, and it's just told us its fingerprint
             elif line.startswith("250-fingerprint="):
                 _, _, fingerprint = line.partition("fingerprint=") # returns: part1, separator, part2
                 self.setDiscoveredValue('set_fingerprint', fingerprint,
-                                        'fingerprint', peer)
+                                        'fingerprint')
                 # waiting mode will skip all further lines, until collection
                 self.state = 'waiting'
             # We asked for its fingerprint, and it said it's a client
             elif line == "551 Not running in server mode":
-                logging.warning("Connection with {}:{}:{} failed: not a relay".format(peer.type, peer.host, peer.port))
+                logging.warning("Connection with {} failed: not a relay"
+                                .format(transport_info(self.transport)))
                 self.quit()
             else:
-                self.handleUnexpectedLine(line, peer)
+                self.handleUnexpectedLine(line)
 
             # If we already know what events we should have enabled, start
             # processing them
@@ -1127,7 +1164,7 @@ class TorControlClientProtocol(LineOnlyReceiver):
                 self.enableEvents()
         elif self.state == 'waiting' and line.startswith("2"):
             # log ok events while we're waiting for round start
-            self.handleUnexpectedLine(line, peer)
+            self.handleUnexpectedLine(line)
         elif self.state == 'processing' and line.startswith("650 PRIVCOUNT_"):
             parts = line.split(" ")
             assert len(parts) > 1
@@ -1144,32 +1181,41 @@ class TorControlClientProtocol(LineOnlyReceiver):
             elif not self.factory.handle_event(parts[1:]):
                 self.quit()
         else:
-            self.handleUnexpectedLine(line, peer)
+            self.handleUnexpectedLine(line)
 
-    def handleUnexpectedLine(self, line, peer):
+    def handleUnexpectedLine(self, line):
         '''
         Log any unexpected responses at an appropriate level.
         Quit on error responses.
         '''
         if line == "250 OK":
-            logging.debug("Connection with {}:{}:{}: ok response: '{}'".format(peer.type, peer.host, peer.port, line))
+            logging.debug("Connection with {}: ok response: '{}'"
+                          .format(transport_info(self.transport), line))
         elif line.startswith("650 PRIVCOUNT_"):
-            logging.warning("Connection with {}:{}:{}: unexpected event: '{}'".format(peer.type, peer.host, peer.port, line))
+            logging.warning("Connection with {}: unexpected event: '{}'"
+                            .format(transport_info(self.transport), line))
         elif line.startswith("5"):
-            logging.warning("Connection with {}:{}:{}: unexpected response: '{}'".format(peer.type, peer.host, peer.port, line))
+            logging.warning("Connection with {}: unexpected response: '{}'"
+                            .format(transport_info(self.transport), line))
             self.quit()
         elif line.startswith("2"):
-            logging.info("Connection with {}:{}:{}: ok response: '{}'".format(peer.type, peer.host, peer.port, line))
+            logging.info("Connection with {}: ok response: '{}'"
+                         .format(transport_info(self.transport), line))
         else:
-            logging.warning("Connection with {}:{}:{}: unexpected response: '{}'".format(peer.type, peer.host, peer.port, line))
+            logging.warning("Connection with {}: unexpected response: '{}'"
+                            .format(transport_info(self.transport), line))
             self.quit()
 
     def quit(self):
         self.sendLine("QUIT")
 
-    def connectionLost(self, reason): # overrides twisted function
-        peer = self.transport.getPeer()
-        logging.debug("Connection with {}:{}:{} was lost: {}".format(peer.type, peer.host, peer.port, reason.getErrorMessage()))
+    def connectionLost(self, reason):
+        '''
+        overrides twisted function
+        '''
+        logging.debug("Connection with {} was lost: {}"
+                      .format(transport_info(self.transport),
+                              reason.getErrorMessage()))
 
 class TorControlServerProtocol(LineOnlyReceiver):
     '''
@@ -1220,18 +1266,18 @@ class TorControlServerProtocol(LineOnlyReceiver):
         '''
         overrides twisted function
         '''
-        peer = self.transport.getPeer()
-        logging.debug("Connection with {}:{}:{} was made".format(peer.type, peer.host, peer.port))
+        logging.debug("Connection with {} was made"
+                      .format(transport_info(self.transport)))
 
     def lineReceived(self, line):
         '''
         overrides twisted function
         '''
-        peer = self.transport.getPeer()
         line = line.strip()
         parts = line.split(' ')
 
-        logging.debug("Received line '{}' from {}:{}:{}".format(line, peer.type, peer.host, peer.port))
+        logging.debug("Received line '{}' from {}"
+                      .format(line, transport_info(self.transport)))
 
         # We use " quotes, but tor uses ' quotes. This should not matter.
         if not self.authenticated:
@@ -1325,5 +1371,6 @@ class TorControlServerProtocol(LineOnlyReceiver):
         '''
         overrides twisted function
         '''
-        peer = self.transport.getPeer()
-        logging.debug("Connection with {}:{}:{} was lost: {}".format(peer.type, peer.host, peer.port, reason.getErrorMessage()))
+        logging.debug("Connection with {} was lost: {}"
+                      .format(transport_info(self.transport),
+                              reason.getErrorMessage()))

--- a/privcount/share_keeper.py
+++ b/privcount/share_keeper.py
@@ -13,12 +13,12 @@ from copy import deepcopy
 from twisted.internet import reactor, ssl
 from twisted.internet.protocol import ReconnectingClientFactory
 
+from privcount.config import normalise_path, choose_secret_handshake_path
 from privcount.counter import SecureCounters, counter_modulus, add_counter_limits_to_config, combine_counters
 from privcount.crypto import get_public_digest, generate_keypair, get_serialized_public_key, load_private_key_file, decrypt
 from privcount.log import log_error
 from privcount.protocol import PrivCountClientProtocol
 from privcount.node import PrivCountClient
-from privcount.util import normalise_path, choose_secret_handshake_path
 
 class ShareKeeper(ReconnectingClientFactory, PrivCountClient):
     '''

--- a/privcount/share_keeper.py
+++ b/privcount/share_keeper.py
@@ -14,6 +14,7 @@ from twisted.internet import reactor, ssl
 from twisted.internet.protocol import ReconnectingClientFactory
 
 from privcount.config import normalise_path, choose_secret_handshake_path
+from privcount.connection import validate_connection_config
 from privcount.counter import SecureCounters, counter_modulus, add_counter_limits_to_config, combine_counters
 from privcount.crypto import get_public_digest, generate_keypair, get_serialized_public_key, load_private_key_file, decrypt
 from privcount.log import log_error
@@ -215,8 +216,8 @@ class ShareKeeper(ReconnectingClientFactory, PrivCountClient):
             sk_conf['sigma_decrease_tolerance'] = \
                 self.get_valid_sigma_decrease_tolerance(sk_conf)
 
-            assert sk_conf['tally_server_info']['ip'] is not None
-            assert sk_conf['tally_server_info']['port'] > 0
+            assert validate_connection_config(sk_conf['tally_server_info'],
+                                           must_have_ip=True)
 
             if self.config == None:
                 self.config = sk_conf

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -16,13 +16,13 @@ from base64 import b64encode
 from twisted.internet import reactor, task, ssl
 from twisted.internet.protocol import ServerFactory
 
+from privcount.config import normalise_path, choose_secret_handshake_path
 from privcount.counter import SecureCounters, counter_modulus, min_blinded_counter_value, max_blinded_counter_value, min_tally_counter_value, max_tally_counter_value, add_counter_limits_to_config, check_noise_weight_config, check_counters_config, CollectionDelay, float_accuracy
 from privcount.crypto import generate_keypair, generate_cert
 from privcount.log import log_error, format_elapsed_time_since, format_elapsed_time_wait, format_delay_time_until, format_interval_time_between, format_last_event_time_since
 from privcount.node import PrivCountServer, continue_collecting, log_tally_server_status
 from privcount.protocol import PrivCountServerProtocol
 from privcount.statistics_noise import get_noise_allocation
-from privcount.util import normalise_path, choose_secret_handshake_path
 
 # for warning about logging function and format # pylint: disable=W1202
 # for calling methods on reactor # pylint: disable=E1101

--- a/privcount/tools/privcount
+++ b/privcount/tools/privcount
@@ -9,8 +9,8 @@ import os
 import logging
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, ArgumentTypeError
 
-from privcount.plot import add_plot_args
 from privcount.inject import add_inject_args
+from privcount.plot import add_plot_args
 
 class CustomHelpFormatter(ArgumentDefaultsHelpFormatter):
     # adds the 'RawDescriptionHelpFormatter' to the ArgsDefault one

--- a/test/README.markdown
+++ b/test/README.markdown
@@ -37,8 +37,9 @@ Activate your python virtual environment (if you have one):
 Run the unit tests: (optional)
 
     python test_format_time.py
-    python test_keyed_random.py
-    python test_counters.py
+    python test_encryption.py
+    python test_random.py
+    python test_counter.py
 
 If you have a local privcount-patched Tor instance on control port 9050, you can test that it supports PRIVCOUNT events: (optional)
 

--- a/test/README.markdown
+++ b/test/README.markdown
@@ -41,9 +41,9 @@ Run the unit tests: (optional)
     python test_random.py
     python test_counter.py
 
-If you have a local privcount-patched Tor instance on control port 9050, you can test that it supports PRIVCOUNT events: (optional)
+If you have a local privcount-patched Tor instance, you can test that it is returning PRIVCOUNT events:
 
-    python test_counters.py
+    python test_tor_ctl_event.py <control-port-or-path>
 
 #### Integration Tests
 

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -60,7 +60,17 @@ share_keeper:
 data_collector:
     name: phantomtrain1 # a unique, human meaningful name for debugging
     state: 'privcount.dc.state' # path to file where persistent state will be stored
-    event_source: 20003 # the Tor control port from which we will receive events
+    # the Tor control connection from which we will receive events
+    # Can be:
+    # - port, with ip optional (default 127.0.0.1), or
+    # - a unix socket path
+    # Only choose one connection method: using multiple methods risks receiving
+    # duplicate events. (We use multiple methods to ensure that both methods
+    # work during testing.)
+    event_source:
+        port: 20003
+        #ip: 127.0.0.1 # optional (default 127.0.0.1), use ::1 for IPv6
+        unix: /tmp/privcount-inject # control socket path. Tor defaults to /var/run/tor/control in many common distributions.
     tally_server_info: # where the tally server is located
         ip: 127.0.0.1
         port: 20001

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -150,7 +150,7 @@ if [ -e privcount.outcome.latest.json -a \
   # events falling before or after data collection stops in short runs
   diff --minimal \
       -I "time" -I "[Cc]lock" -I "alive" -I "rtt" -I "Start" -I "Stop" \
-      -I "[Dd]elay" -I "Collect" -I "End" \
+      -I "[Dd]elay" -I "Collect" -I "End" -I "peer" \
       old/privcount.outcome.latest.json privcount.outcome.latest.json || true
 else
   # Since we need old/latest and latest, it takes two runs to generate the

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -73,7 +73,7 @@ mkdir -p old
 mv privcount.* old/ || true
 
 # Then run the injector, ts, sk, and dc
-echo "Launching injector, tally server, share keeper, and data collector..."
+echo "Launching injector (IP), tally server, share keeper, and data collector..."
 privcount inject --simulate --port 20003 --log events.txt &
 privcount ts config.yaml &
 privcount sk config.yaml &
@@ -100,8 +100,9 @@ while echo "$JOB_STATUS" | grep -q "Running"; do
       echo "Moving round $ROUNDS results files to '$PRIVCOUNT_DIRECTORY/test/old' ..."
       mv privcount.* old/ || true
       ROUNDS=$[$ROUNDS+1]
-      echo "Restarting injector for round $ROUNDS..."
-      privcount inject --simulate --port 20003 --log events.txt &
+      echo "Restarting injector (unix path) for round $ROUNDS..."
+      privcount inject --simulate --unix /tmp/privcount-inject \
+          --log events.txt &
     else
       ROUNDS=$[$ROUNDS+1]
       break

--- a/test/test_counter.py
+++ b/test/test_counter.py
@@ -5,9 +5,10 @@
 
 import sys
 
-from privcount.counter import SecureCounters, adjust_count_signed, counter_modulus, add_counter_limits_to_config, get_events_for_known_counters
 from math import sqrt
 from random import SystemRandom
+
+from privcount.counter import SecureCounters, adjust_count_signed, counter_modulus, add_counter_limits_to_config, get_events_for_known_counters
 
 import logging
 # DEBUG logs every check: use it on failure

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -12,8 +12,8 @@ from base64 import b64encode, b64decode
 from os import urandom
 from random import SystemRandom
 
-from privcount.crypto import load_public_key_file, load_private_key_file, encrypt_pk, decrypt_pk, generate_symmetric_key, encrypt_symmetric, decrypt_symmetric, encode_data, decode_data, encrypt, decrypt
 from privcount.counter import counter_modulus
+from privcount.crypto import load_public_key_file, load_private_key_file, encrypt_pk, decrypt_pk, generate_symmetric_key, encrypt_symmetric, decrypt_symmetric, encode_data, decode_data, encrypt, decrypt
 
 import logging
 # DEBUG logs every check: use it on failure

--- a/test/test_tor_ctl_event.py
+++ b/test/test_tor_ctl_event.py
@@ -1,23 +1,46 @@
 #!/usr/bin/env python
-# Test that a local control port provides PrivCount events
+# Test that a local control port (IP or unix socket) provides PrivCount events
 
+import logging
 import sys
+
+from collections import Sequence
+from os import path
 
 from twisted.internet import reactor
 from twisted.internet.protocol import ReconnectingClientFactory
 
+from privcount.connection import connect, transport_info
 from privcount.protocol import TorControlClientProtocol, get_valid_events
 
-# Usage:
+## Usage:
+#
+## Setup
 # cd privcount/tor
 # ./configure && make check && make test-network-all
-# src/or/tor PublishServerDescriptor 0 ControlPort 9051 ORPort 9001 DirPort 9030 ExitRelay 0 DataDirectory `mktemp -d`
+#
+## Control Socket (relies on filesystem security, more secure)
+# mkdir -p /var/run/tor
+# chmod go-rwx /var/run/tor
+# src/or/tor PublishServerDescriptor 0 ORPort 9001 DirPort 9030 ExitRelay 0 DataDirectory `mktemp -d` ControlSocket /var/run/tor/control
+#
+## OR
+#
+## Control Port (any local process can access the control port, less secure)
+# src/or/tor PublishServerDescriptor 0 ORPort 9001 DirPort 9030 ExitRelay 0 DataDirectory `mktemp -d` ControlPort 9051
+#
+## Testing
 # source venv/bin/activate
 # python test/test_tor_ctl_event.py
-# wait a few minutes for the first events to arrive
+## wait a few minutes for the first events to arrive
+
+# The default control socket path used by Debian
+TOR_CONTROL_PATH = '/var/run/tor/control'
 
 # The typical control port listed in the tor manual
-TOR_CONTROL_PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 9051
+TOR_CONTROL_PORT = 9051
+# Try localhost on this IP version
+TOR_CONTROL_IP_VERSION = 4
 
 class TorCtlClient(ReconnectingClientFactory):
     '''
@@ -30,15 +53,16 @@ class TorCtlClient(ReconnectingClientFactory):
         Make sure the stored nickname is initialised
         '''
         self.nickname = None
+        self.client = None
 
     def buildProtocol(self, addr):
         '''
         Called by twisted
         '''
-        client = TorControlClientProtocol(self)
+        self.client = TorControlClientProtocol(self)
         # ask for all the events
-        client.startCollection(None, event_list=get_valid_events())
-        return client
+        self.client.startCollection(None, event_list=get_valid_events())
+        return self.client
 
     def set_nickname(self, nickname):
         '''
@@ -65,8 +89,53 @@ class TorCtlClient(ReconnectingClientFactory):
             nickname = ""
         else:
             nickname = self.nickname + " "
-        print "{}got PRIVCOUNT_* event: {}".format(nickname, " ".join(event))
+        address = transport_info(self.client.transport)
+        print "{}{} got PRIVCOUNT_* event: {}".format(nickname,
+                                                      address,
+                                                      " ".join(event))
         return True
 
-reactor.connectTCP("127.0.0.1", TOR_CONTROL_PORT, TorCtlClient())
+# Set defaults
+control_path = TOR_CONTROL_PATH
+control_port = TOR_CONTROL_PORT
+
+# Process command-line arguments
+if len(sys.argv) > 1:
+    # UNIX socket path
+    if path.exists(sys.argv[1]):
+        control_path = sys.argv[1]
+    else:
+        control_path = None
+
+    # IP port
+    try:
+        control_port = int(sys.argv[1])
+    except ValueError:
+        control_port = None
+
+# Just try every possible method, and let the ones that don't work fail
+# (if they all succeed, it will be terribly confusing)
+# Don't use multiple configs in production, it's only useful for testing
+config_list = []
+
+if control_path is not None:
+    path_config = { 'unix' : control_path }
+    config_list.append(path_config)
+
+if control_port is not None:
+    port_config = { 'port' : control_port }
+    config_list.append(port_config)
+
+
+# Trying localhost is sufficient: a service bound to all ports will answer
+# on localhost (and expose control of your tor to the entire world).
+connector = connect(TorCtlClient(),
+                    config_list,
+                    ip_version_default = TOR_CONTROL_IP_VERSION)
+
+if isinstance(connector, (Sequence)):
+    logging.warning("If you have ControlPorts listening on both path {} and IPv{} localhost port {}, some events may be attributed to the wrong address, or duplicated."
+                    .format(TOR_CONTROL_IP_VERSION,
+                            control_path,
+                            control_port))
 reactor.run()


### PR DESCRIPTION
Allow PrivCount data collectors to connect over a control socket or a control port, depending on their config.