### PR TITLE
Fix injector so it works without --simulate

### DIFF
--- a/privcount/connection.py
+++ b/privcount/connection.py
@@ -112,6 +112,17 @@ def listen_ip(factory, config, ip_local_default=True, ip_version_default=4):
                                                        interface=ip))
     return _unlistify(listeners)
 
+def stopListening(listener):
+    '''
+    Make listener stop listening.
+    If listener is a list, stop all listeners in the list.
+    '''
+    # upgrade the listener to a list if it has been passed as a single item
+    listener = _listify(listener)
+    # now process the list
+    for item in listener:
+        item.stopListening()
+
 def connect(factory, config, ip_local_default=True, ip_version_default=4):
     '''
     Set up factory to connect to service, based on config, which is a
@@ -201,7 +212,8 @@ def connect_ip(factory, config, ip_local_default=True, ip_version_default=4):
 
 def disconnect(connector):
     '''
-    Disconnect all connectors in connector.
+    Disconnect connector.
+    If connector is a list, disconnect all connectors in the list.
     '''
     # upgrade the connector to a list if it has been passed as a single item
     connector = _listify(connector)

--- a/privcount/inject.py
+++ b/privcount/inject.py
@@ -192,8 +192,7 @@ def add_inject_args(parser):
                         default='-')
     parser.add_argument('-s', '--simulate',
                         action='store_true',
-                        help="add pauses between each event injection to simulate the inter-arrival times from the source data",
-                        default=True)
+                        help="add pauses between each event injection to simulate the inter-arrival times from the source data")
     parser.add_argument('--prune-before',
                         help="do not inject events that occurred before the given unix timestamp",
                         default=0)

--- a/privcount/inject.py
+++ b/privcount/inject.py
@@ -17,6 +17,8 @@ from privcount.config import normalise_path
 from privcount.connection import listen
 from privcount.protocol import TorControlServerProtocol
 
+# We can't have the injector listen on a port by default, because it might
+# conflict with a running tor instance
 DEFAULT_PRIVCOUNT_INJECT_SOCKET = '/tmp/privcount-inject'
 
 listener = None
@@ -177,7 +179,7 @@ def add_inject_args(parser):
                         help="port on which to listen for PrivCount connections(default: no IP listener)",
                         required=False)
     parser.add_argument('-i', '--ip',
-                        help="IPv4 or IPv6 address on which to listen for PrivCount connections (default: both 127.0.0.1 and ::1)",
+                        help="IPv4 or IPv6 address on which to listen for PrivCount connections (default: both 127.0.0.1 and ::1, if a port is specified)",
                         required=False)
     parser.add_argument('-u', '--unix',
                         help="Unix socket on which to listen for PrivCount connections (default: '{}')"

--- a/privcount/inject.py
+++ b/privcount/inject.py
@@ -17,6 +17,9 @@ from privcount.config import normalise_path
 from privcount.connection import listen
 from privcount.protocol import TorControlServerProtocol
 
+# set the log level
+#logging.basicConfig(level=logging.DEBUG)
+
 # We can't have the injector listen on a port by default, because it might
 # conflict with a running tor instance
 DEFAULT_PRIVCOUNT_INJECT_SOCKET = '/tmp/privcount-inject'

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -1070,6 +1070,14 @@ class TorControlClientProtocol(LineOnlyReceiver):
                             .format(transport_info(self.transport),
                                     value_name, value, e))
 
+    def sendLine(self, line):
+        '''
+        overrides twisted function
+        '''
+        logging.debug("Sending line '{}' to {}"
+                      .format(line, transport_info(self.transport)))
+        return LineOnlyReceiver.sendLine(self, line)
+
     def lineReceived(self, line):
         '''
         Check that authentication was successful.
@@ -1268,6 +1276,14 @@ class TorControlServerProtocol(LineOnlyReceiver):
         '''
         logging.debug("Connection with {} was made"
                       .format(transport_info(self.transport)))
+
+    def sendLine(self, line):
+        '''
+        overrides twisted function
+        '''
+        logging.debug("Sending line '{}' to {}"
+                      .format(line, transport_info(self.transport)))
+        return LineOnlyReceiver.sendLine(self, line)
 
     def lineReceived(self, line):
         '''

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -1309,14 +1309,17 @@ class TorControlServerProtocol(LineOnlyReceiver):
                 upper_setevents = map(str.upper, parts[1:])
                 # already uppercase
                 upper_known_events = get_valid_events()
-                # if every requested event is in the known events
-                # if there are no requested events, that's ok, it turns events
-                # off
-                if set(upper_setevents).issubset(upper_known_events):
+                upper_setevents = set(upper_setevents)
+                if len(upper_setevents) == 0:
+                    # if there are no requested events, turn events off
+                    self.sendLine("250 OK")
+                    self.factory.stop_injecting()
+                elif upper_setevents.issubset(upper_known_events):
+                    # if every requested event is in the known events
                     self.sendLine("250 OK")
                     self.factory.start_injecting()
                 else:
-                    unknown_events = set(upper_setevents).difference(
+                    unknown_events = upper_setevents.difference(
                         upper_known_events)
                     assert len(unknown_events) > 0
                     # this line displays the event name uppercased

--- a/test/README.markdown
+++ b/test/README.markdown
@@ -49,7 +49,7 @@ If you have a local privcount-patched Tor instance, you can test that it is retu
 
 Start the event server that will supply events to the data collector:
 
-    privcount inject --simulate --port 20003 --log events.txt
+    privcount inject --port 20003 --log events.txt
 
 Start the PrivCount components:
 

--- a/test/README.markdown
+++ b/test/README.markdown
@@ -66,3 +66,7 @@ If you have matplotlib installed, you can then visualize the results:
     privcount plot -d privcount.tallies.*.json test
 
 and open the PDF file that was created.
+
+The full results, including context, are in:
+
+    privcount.outcome.*.json

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -74,7 +74,9 @@ mv privcount.* old/ || true
 
 # Then run the injector, ts, sk, and dc
 echo "Launching injector (IP), tally server, share keeper, and data collector..."
-privcount inject --simulate --port 20003 --log events.txt &
+# We can either test --simulate, and get partial data, or get full data
+# It's better to get full data
+privcount inject --port 20003 --log events.txt &
 privcount ts config.yaml &
 privcount sk config.yaml &
 privcount dc config.yaml &
@@ -101,7 +103,7 @@ while echo "$JOB_STATUS" | grep -q "Running"; do
       mv privcount.* old/ || true
       ROUNDS=$[$ROUNDS+1]
       echo "Restarting injector (unix path) for round $ROUNDS..."
-      privcount inject --simulate --unix /tmp/privcount-inject \
+      privcount inject --unix /tmp/privcount-inject \
           --log events.txt &
     else
       ROUNDS=$[$ROUNDS+1]

--- a/test/test_tor_ctl_event.py
+++ b/test/test_tor_ctl_event.py
@@ -35,7 +35,8 @@ from privcount.protocol import TorControlClientProtocol, get_valid_events
 ## Testing
 # source venv/bin/activate
 # python test/test_tor_ctl_event.py
-## wait a few minutes for the first events to arrive
+## wait a few minutes for the first events to arrive, or just terminate tor
+## using a SIGINT after it has made some connections
 
 # The default control socket path used by Debian
 TOR_CONTROL_PATH = '/var/run/tor/control'

--- a/test/test_tor_ctl_event.py
+++ b/test/test_tor_ctl_event.py
@@ -13,6 +13,9 @@ from twisted.internet.protocol import ReconnectingClientFactory
 from privcount.connection import connect, transport_info
 from privcount.protocol import TorControlClientProtocol, get_valid_events
 
+# set the log level
+#logging.basicConfig(level=logging.DEBUG)
+
 ## Usage:
 #
 ## Setup

--- a/test/test_tor_ctl_event.py
+++ b/test/test_tor_ctl_event.py
@@ -86,7 +86,7 @@ class TorCtlClient(ReconnectingClientFactory):
     def handle_event(self, event):
         '''
         Called when an event occurs.
-        event is a space-separated list of tokens from the event line
+        event is a list of tokens from the event line, split on spaces
         '''
         if self.nickname is None:
             nickname = ""


### PR DESCRIPTION
The injector would fill the output buffer without giving the twisted event loop time to send it.
It would also drop the last event line, failing to send it to the client.

Needed for #19.
Summary issue is #154.