### PR TITLE
Implement Control Port Password and Safe Cookie authentication

### DIFF
--- a/privcount/connection.py
+++ b/privcount/connection.py
@@ -293,6 +293,8 @@ def get_a_control_password(config):
         # Using different passwords on different items is not supported
         # (we don't match up the connection info)
         item = choose_a_connection_with(config, 'control_password')
+        if item is None:
+            return None
         return item.get('control_password', None)
 
 def choose_a_connection_with(config, attribute):

--- a/privcount/crypto.py
+++ b/privcount/crypto.py
@@ -94,7 +94,7 @@ def verify_hmac(expected_result, secret_key, unique_prefix, data):
     try:
         h.verify(bytes(expected_result))
         return True
-    except cryptography.exceptions.InvalidSignature:
+    except InvalidSignature:
         return False
 
 def b64_raw_length(byte_count):

--- a/privcount/data_collector.py
+++ b/privcount/data_collector.py
@@ -13,7 +13,7 @@ from twisted.internet import task, reactor, ssl
 from twisted.internet.protocol import ReconnectingClientFactory
 
 from privcount.config import normalise_path, choose_secret_handshake_path
-from privcount.connection import connect, disconnect, validate_connection_config, choose_a_connection
+from privcount.connection import connect, disconnect, validate_connection_config, choose_a_connection, get_a_control_password
 from privcount.counter import SecureCounters, counter_modulus, add_counter_limits_to_config, combine_counters
 from privcount.crypto import get_public_digest_string, load_public_key_string, encrypt
 from privcount.log import log_error, format_delay_time_wait, format_last_event_time_since
@@ -416,6 +416,14 @@ class Aggregator(ReconnectingClientFactory):
             # stop collecting and stop counting
             self._stop_protocol()
             self._stop_secure_counters(counts_are_valid=False)
+
+    def get_control_password(self):
+        '''
+        Return the configured control password for this data collector, or
+        None if no connections have a control password.
+        '''
+        # Multiple different control passwords are not supported
+        return get_a_control_password(self.tor_control_port)
 
     def set_nickname(self, nickname):
         nickname = nickname.strip()

--- a/privcount/data_collector.py
+++ b/privcount/data_collector.py
@@ -516,7 +516,15 @@ class Aggregator(ReconnectingClientFactory):
         # Are we replacing an existing version?
         if self.version is not None:
             if self.version != version:
-                logging.warning("Replacing version %s with %s", self.version, version)
+                if self.version.lower() in version.lower():
+                    # we just added a git tag to the version
+                    # this happens because GETINFO version has the tag, but
+                    # PROTOCOLINFO does not
+                    logging_level = logging.debug
+                else:
+                    # did someone just restart tor with a new version?
+                    logging_level = logging.warning
+                logging_level("Replacing version %s with %s", self.version, version)
             else:
                 logging.debug("Duplicate version received %s", version)
 

--- a/privcount/inject.py
+++ b/privcount/inject.py
@@ -26,7 +26,8 @@ DEFAULT_PRIVCOUNT_INJECT_SOCKET = '/tmp/privcount-inject'
 
 class PrivCountDataInjector(ServerFactory):
 
-    def __init__(self, logpath, do_pause, prune_before, prune_after):
+    def __init__(self, logpath, do_pause, prune_before, prune_after,
+                 control_password = None):
         self.logpath = logpath
         self.do_pause = do_pause
         self.prune_before = prune_before
@@ -36,6 +37,7 @@ class PrivCountDataInjector(ServerFactory):
         self.last_time_end = 0.0
         self.injecting = False
         self.listeners = None
+        self.control_password = control_password
 
     def startFactory(self):
         # TODO
@@ -58,6 +60,14 @@ class PrivCountDataInjector(ServerFactory):
         # (temporary) reference loop. Perhaps there is a better way of
         # retrieving all the listeners for a factory?
         self.listeners = listener_list
+
+    def get_control_password(self):
+        '''
+        Return the configured control password, or None if there is no control
+        password.
+        '''
+        # Configuring multiple passwords is not supported
+        return self.control_password
 
     def start_injecting(self):
         self.injecting = True
@@ -196,7 +206,7 @@ def run_inject(args):
     start the injector, and start it listening
     '''
     # pylint: disable=E1101
-    injector = PrivCountDataInjector(args.log, args.simulate, int(args.prune_before), int(args.prune_after))
+    injector = PrivCountDataInjector(args.log, args.simulate, int(args.prune_before), int(args.prune_after), args.control_password)
     # The injector listens on all of IPv4, IPv6, and a control socket, and
     # injects events into the first client to connect
     # Since these are synthetic events, it is safe to use /tmp for the socket
@@ -236,6 +246,8 @@ def add_inject_args(parser):
     parser.add_argument('--prune-after',
                         help="do not inject events that occurred after the given unix timestamp",
                         default=2147483647)
+    parser.add_argument('--control-password',
+                        help="The tor control password, set via tor --hash-password and HashedControlPassword")
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/privcount/inject.py
+++ b/privcount/inject.py
@@ -27,7 +27,7 @@ DEFAULT_PRIVCOUNT_INJECT_SOCKET = '/tmp/privcount-inject'
 class PrivCountDataInjector(ServerFactory):
 
     def __init__(self, logpath, do_pause, prune_before, prune_after,
-                 control_password = None):
+                 control_password = None, control_cookie_file = None):
         self.logpath = logpath
         self.do_pause = do_pause
         self.prune_before = prune_before
@@ -38,6 +38,7 @@ class PrivCountDataInjector(ServerFactory):
         self.injecting = False
         self.listeners = None
         self.control_password = control_password
+        self.control_cookie_file = control_cookie_file
 
     def startFactory(self):
         # TODO
@@ -68,6 +69,14 @@ class PrivCountDataInjector(ServerFactory):
         '''
         # Configuring multiple passwords is not supported
         return self.control_password
+
+    def get_control_cookie_file(self):
+        '''
+        Return the configured control cookie file path, or None if there is no
+        control cookie file.
+        '''
+        # Configuring multiple cookie files is not supported
+        return self.control_cookie_file
 
     def start_injecting(self):
         self.injecting = True
@@ -206,7 +215,7 @@ def run_inject(args):
     start the injector, and start it listening
     '''
     # pylint: disable=E1101
-    injector = PrivCountDataInjector(args.log, args.simulate, int(args.prune_before), int(args.prune_after), args.control_password)
+    injector = PrivCountDataInjector(args.log, args.simulate, int(args.prune_before), int(args.prune_after), args.control_password, args.control_cookie_file)
     # The injector listens on all of IPv4, IPv6, and a control socket, and
     # injects events into the first client to connect
     # Since these are synthetic events, it is safe to use /tmp for the socket
@@ -247,7 +256,9 @@ def add_inject_args(parser):
                         help="do not inject events that occurred after the given unix timestamp",
                         default=2147483647)
     parser.add_argument('--control-password',
-                        help="The tor control password, set via tor --hash-password and HashedControlPassword")
+                        help="The tor control password. Set this in tor using tor --hash-password and HashedControlPassword")
+    parser.add_argument('--control-cookie-file',
+                        help="The tor control cookie file. Set this in tor using CookieAuthentication and CookieAuthFile")
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/privcount/inject.py
+++ b/privcount/inject.py
@@ -72,7 +72,7 @@ class PrivCountDataInjector(ServerFactory):
     def start_injecting(self):
         self.injecting = True
         if self.listeners is not None:
-            logging.info("Injector is no longer listening")
+            logging.info("Injector has connected: no longer listening for new connections")
             stopListening(self.listeners)
             # This breaks the reference loop
             self.listeners = None

--- a/privcount/inject.py
+++ b/privcount/inject.py
@@ -221,10 +221,8 @@ def add_inject_args(parser):
                         help="IPv4 or IPv6 address on which to listen for PrivCount connections (default: both 127.0.0.1 and ::1, if a port is specified)",
                         required=False)
     parser.add_argument('-u', '--unix',
-                        help="Unix socket on which to listen for PrivCount connections (default: '{}')"
-                        .format(DEFAULT_PRIVCOUNT_INJECT_SOCKET),
-                        required=False,
-                        default=DEFAULT_PRIVCOUNT_INJECT_SOCKET)
+                        help="Unix socket on which to listen for PrivCount connections (default: no unix listener)",
+                        required=False)
     parser.add_argument('-l', '--log',
                         help="a file PATH to a PrivCount event log file, may be '-' for STDIN (default: STDIN)",
                         required=True,

--- a/privcount/node.py
+++ b/privcount/node.py
@@ -19,21 +19,24 @@ def get_remaining_rounds(num_phases, continue_config):
         rounds, return the number of rounds. Otherwise, if it will continue
         forever, return None.
         '''
+        # run at least once
+        min_remaining = 0
         if num_phases == 0:
-            return 1
+            min_remaining = 1
         if isinstance(continue_config, bool):
             if continue_config:
                 return None
             else:
-                return 0
+                return max(0, min_remaining)
         else:
-            return continue_config - num_phases
+            return max(continue_config - num_phases, min_remaining)
 
 def continue_collecting(num_phases, continue_config):
         '''
         If the TS is configured to continue collecting more rounds,
         return True. Otherwise, return False.
         '''
+        # run at least once
         if num_phases == 0:
             return True
         if isinstance(continue_config, bool):

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -1055,21 +1055,21 @@ class TorControlClientProtocol(LineOnlyReceiver):
             self.active_events = None
             self.state = 'waiting'
 
-    def setDiscoveredValue(self, function_name, value, value_name):
+    def setDiscoveredValue(self, set_function_name, value, value_name):
         '''
-        When we discover value from the relay, call set_function to set it,
-        and log a message containing value_name if this fails.
+        When we discover value from the relay, call factory.set_function_name
+        to set it, and log a message containing value_name if this fails.
         '''
         try:
-            # Equivalent to self.factory.set_*(value)
-            if not getattr(self.factory, function_name)(value):
-                logging.warning("Connection with {}: bad {}: {}"
+            # Equivalent to self.factory.set_function_name(value)
+            if not getattr(self.factory, set_function_name)(value):
+                logging.warning("Connection with {}: bad {} set via {}: {}"
                                 .format(transport_info(self.transport),
-                                        value_name, value))
+                                        value_name, set_function_name, value))
         except AttributeError as e:
-            logging.warning("Connection with {}: sent {}: {}, but factory raised {}"
+            logging.warning("Connection with {}: tried to set {} via {}: {}, but factory raised {}"
                             .format(transport_info(self.transport),
-                                    value_name, value, e))
+                                    value_name, set_function_name, value, e))
 
     def sendLine(self, line):
         '''

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -1365,7 +1365,7 @@ class TorControlServerProtocol(LineOnlyReceiver):
                 # Assume the protocolinfo version is OK
                 self.sendLine("250-PROTOCOLINFO 1")
                 # We don't do COOKIE authentication, it's not secure
-                self.sendLine("250-AUTH METHODS=SAFECOOKIE,PASSWORD,NULL COOKIEFILE=\"/var/run/tor/control.authcookie\"")
+                self.sendLine("250-AUTH METHODS=SAFECOOKIE,HASHEDPASSWORD,NULL COOKIEFILE=\"/var/run/tor/control.authcookie\"")
                 self.sendLine("250-VERSION Tor=\"0.2.8.6\"")
                 self.sendLine("250 OK")
             elif line == "AUTHENTICATE":

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -1247,6 +1247,7 @@ class TorControlClientProtocol(LineOnlyReceiver, TorControlProtocol):
                 logging.critical("Connection with {}: does not support PrivCount"
                                  .format(transport_info(self.transport)))
                 self.quit()
+                return
             # It's a relay, and it's just told us its Nickname
             elif line.startswith("250 Nickname="):
                 _, _, nickname = line.partition("Nickname=")
@@ -1303,6 +1304,7 @@ class TorControlClientProtocol(LineOnlyReceiver, TorControlProtocol):
                 logging.warning("Connection with {} failed: not a relay"
                                 .format(transport_info(self.transport)))
                 self.quit()
+                return
             else:
                 self.handleUnexpectedLine(line)
 
@@ -1328,6 +1330,7 @@ class TorControlClientProtocol(LineOnlyReceiver, TorControlProtocol):
                 logging.warning("Event with no data {}".format(line))
             elif not self.factory.handle_event(parts[1:]):
                 self.quit()
+                return
         else:
             self.handleUnexpectedLine(line)
 
@@ -1468,9 +1471,11 @@ class TorControlServerProtocol(LineOnlyReceiver, TorControlProtocol):
                 else:
                     self.sendLine("515 Authentication failed: Password did not match HashedControlPassword *or* authentication cookie.")
                     self.transport.loseConnection()
+                    return
             else:
                 self.sendLine("514 Authentication required.")
                 self.transport.loseConnection()
+                return
         elif len(parts) > 0:
             if parts[0] == "SETEVENTS":
                 # events are case-insensitive, so convert to uppercase
@@ -1549,6 +1554,7 @@ class TorControlServerProtocol(LineOnlyReceiver, TorControlProtocol):
                 self.factory.stop_injecting()
                 self.sendLine("250 closing connection")
                 self.transport.loseConnection()
+                return
             else:
                 self.sendLine('510 Unrecognized command "{}"'.format(parts[0]))
         else:

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -1114,7 +1114,7 @@ class TorControlClientProtocol(LineOnlyReceiver):
                 self.quit()
             # It's a relay, and it's just told us its Nickname
             elif line.startswith("250 Nickname="):
-                _, _, nickname = line.partition("Nickname=") # returns: part1, separator, part2
+                _, _, nickname = line.partition("Nickname=")
                 self.setDiscoveredValue('set_nickname', nickname, 'Nickname')
             # It doesn't have a Nickname, maybe it's a client?
             # But we'll catch that when we check the fingerprint, so just ignore this response
@@ -1123,7 +1123,7 @@ class TorControlClientProtocol(LineOnlyReceiver):
                              .format(transport_info(self.transport)))
             # It's a relay, and it's just told us its ORPort
             elif line.startswith("250 ORPort="):
-                _, _, orport = line.partition("ORPort=") # returns: part1, separator, part2
+                _, _, orport = line.partition("ORPort=")
                 self.setDiscoveredValue('set_orport', orport, 'ORPort')
             # It doesn't have an ORPort, maybe it's a client?
             # But we'll catch that when we check the fingerprint, so just ignore this response
@@ -1132,7 +1132,7 @@ class TorControlClientProtocol(LineOnlyReceiver):
                                 .format(transport_info(self.transport)))
             # It's a relay, and it's just told us its DirPort
             elif line.startswith("250 DirPort="):
-                _, _, dirport = line.partition("DirPort=") # returns: part1, separator, part2
+                _, _, dirport = line.partition("DirPort=")
                 self.setDiscoveredValue('set_dirport', dirport, 'DirPort')
             elif line == "250 DirPort":
                 logging.info("Connection with {}: no DirPort"
@@ -1140,11 +1140,11 @@ class TorControlClientProtocol(LineOnlyReceiver):
             # It's just told us its version
             # The control spec assumes that Tor always has a version, so there's no error case
             elif line.startswith("250-version="):
-                _, _, version = line.partition("version=") # returns: part1, separator, part2
+                _, _, version = line.partition("version=")
                 self.setDiscoveredValue('set_version', version, 'version')
             # It's just told us its address
             elif line.startswith("250-address="):
-                _, _, address = line.partition("address=") # returns: part1, separator, part2
+                _, _, address = line.partition("address=")
                 self.setDiscoveredValue('set_address', address, 'address')
             # We asked for its address, and it couldn't find it. That's weird.
             elif line == "551 Address unknown":
@@ -1153,7 +1153,7 @@ class TorControlClientProtocol(LineOnlyReceiver):
             # -- fingerprint discovery ends in waiting or quit() --
             # It's a relay, and it's just told us its fingerprint
             elif line.startswith("250-fingerprint="):
-                _, _, fingerprint = line.partition("fingerprint=") # returns: part1, separator, part2
+                _, _, fingerprint = line.partition("fingerprint=")
                 self.setDiscoveredValue('set_fingerprint', fingerprint,
                                         'fingerprint')
                 # waiting mode will skip all further lines, until collection

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -129,6 +129,8 @@ class PrivCountProtocol(LineOnlyReceiver):
 
     # PrivCount uses a HMAC-SHA256-based handshake to verify that client and
     # server both know a shared secret key, without revealing the key itself
+    # The handshake's construction is similar to the Tor Control Port's
+    # SAFECOOKIE authentication method.
 
     # The numbers of space-seprated parts on various protocol handshake lines
 

--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -965,6 +965,8 @@ class CollectionPhase(object):
             tally_was_successful = tallied_counter.tally_counters(
                 self.final_counts.values())
 
+        begin = int(round(self.starting_ts))
+        end = int(round(self.stopping_ts))
         # keep going, we want the context for debugging
         if not tally_was_successful:
             logging.warning("problem tallying counters, did all counters and bins match!?")
@@ -973,8 +975,6 @@ class CollectionPhase(object):
 
             # For backwards compatibility, write out a "tallies" file
             # This file only has the counts
-            begin = int(round(self.starting_ts))
-            end = int(round(self.stopping_ts))
             filepath = os.path.join(path_prefix,
                                     "privcount.tallies.{}-{}.json"
                                     .format(begin, end))

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -71,6 +71,10 @@ data_collector:
         port: 20003
         #ip: 127.0.0.1 # optional (default 127.0.0.1), use ::1 for IPv6
         unix: '/tmp/privcount-inject' # control socket path. Tor defaults to /var/run/tor/control in many common distributions.
+        #control_password: ''
+        # a password for tor controller authentication
+        # set HashedControlPassword with the output of tor --hash-password ...
+        # passwords are not supported with multiple connection methods
     tally_server_info: # where the tally server is located
         ip: 127.0.0.1
         port: 20001

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -46,7 +46,7 @@ tally_server:
 share_keeper:
     state: 'privcount.sk.state' # path to file where persistent state will be stored
     tally_server_info: # where the tally server is located
-        ip: 127.0.0.1
+        ip: '127.0.0.1'
         port: 20001
     # optional overrides:
     key: 'keys/sk.pem' # path to the rsa private key
@@ -58,7 +58,7 @@ share_keeper:
 
 # only the data collectors need these
 data_collector:
-    name: phantomtrain1 # a unique, human meaningful name for debugging
+    name: 'phantomtrain1' # a unique, human meaningful name for debugging
     state: 'privcount.dc.state' # path to file where persistent state will be stored
     # the Tor control connection from which we will receive events
     # Can be:
@@ -70,7 +70,7 @@ data_collector:
     event_source:
         port: 20003
         #ip: 127.0.0.1 # optional (default 127.0.0.1), use ::1 for IPv6
-        unix: /tmp/privcount-inject # control socket path. Tor defaults to /var/run/tor/control in many common distributions.
+        unix: '/tmp/privcount-inject' # control socket path. Tor defaults to /var/run/tor/control in many common distributions.
     tally_server_info: # where the tally server is located
         ip: 127.0.0.1
         port: 20001

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -236,6 +236,7 @@ fi
 echo "Extracting warnings from privcount output..."
 grep -v -e NOTICE -e INFO -e DEBUG \
   -e "seconds of user activity" -e "delay_period not specified" \
+  -e "control port has no authentication" \
   privcount.*.latest.log \
   || true
 

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -87,8 +87,11 @@ $MOVE_LOG_COMMAND || true
 # We can either test --simulate, and get partial data, or get full data
 # It's better to get full data
 INJECTOR_BASE_CMD="privcount inject --log events.txt"
-INJECTOR_PORT_CMD="$INJECTOR_BASE_CMD --port 20003"
-INJECTOR_UNIX_CMD="$INJECTOR_BASE_CMD --unix /tmp/privcount-inject"
+# Use NULL authentication, because password authentication requires hard-coding
+# a value, and people might re-use it without thinking of security
+INJECTOR_PORT_CMD="$INJECTOR_BASE_CMD --port 20003" # --control-password
+# Use safecookie authentication (our client prefers SAFECOOKIE to PASSWORD)
+INJECTOR_UNIX_CMD="$INJECTOR_BASE_CMD --unix /tmp/privcount-inject --control-cookie-file /tmp/privcount-control-auth-cookie"
 
 # Generate a log file name
 # Usage:

--- a/test/test_tor_ctl_event.py
+++ b/test/test_tor_ctl_event.py
@@ -34,7 +34,7 @@ from privcount.protocol import TorControlClientProtocol, get_valid_events
 #
 ## Testing
 # source venv/bin/activate
-# python test/test_tor_ctl_event.py
+# python test/test_tor_ctl_event.py [ unix_socket_path | control_port ]
 ## wait a few minutes for the first events to arrive, or just terminate tor
 ## using a SIGINT after it has made some connections
 


### PR DESCRIPTION
This allows relay operators to set a password:
* tor: HashedControlPassword 
* PrivCount: control_password

or cookie file:
* tor: CookieAuthentication
* PrivCount: no config required

and have PrivCount securely authenticate to the control port / socket.