### PR TITLE
Fix password security, and document PrivCount security

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -78,18 +78,34 @@ To run PrivCount, simply activate the virtual environment that you created earli
 
 # deployment
 
-## keys
+## PrivCount keys
 
 On first run, PrivCount creates the keys that it needs to run:
 
 The TallyServer creates a RSA key pair for SSL encryption:
-    * the clients do not check the fingerprint of the certificate
+    * no configuration is required: clients do not check this key
 
 The TallyServer creates a PrivCount secret handshake key:
-    * each ShareKeeper and DataCollector needs to know this key to successfully handshake with the TallyServer.
+    * each ShareKeeper and DataCollector needs to know this key to
+      successfully handshake with the TallyServer
 
 Each ShareKeeper creates a RSA key pair for public key encryption:
-     * each DataCollector needs to know the SHA256 hash of the public key of each ShareKeeper
+     * each DataCollector needs to know the SHA256 hash of the public key of
+       each ShareKeeper
+
+See doc/PrivCountAuthentication.markdown for more details.
+
+## Tor Control Authentication
+
+
+PrivCount securely authenticates to tor's control port. This prevents the
+control port being used to run commands as the tor user.
+
+Password authentication requires a shared secret configured using the
+event_source's control_password option. Cookie authentication requires the
+PrivCount user to have read access to tor's cookie file.
+
+See doc/TorControlAuthentication.markdown for more details.
 
 # testing
 

--- a/doc/PrivCountAuthentication.markdown
+++ b/doc/PrivCountAuthentication.markdown
@@ -1,0 +1,47 @@
+# PrivCount Authentication
+
+On first run, PrivCount creates the keys that it needs to run:
+
+The TallyServer creates a RSA key pair for SSL encryption:
+    * client SSL certificate fingerprint checks are not yet implemented
+    * no configuration is required
+    * the private key must be kept secret
+
+The TallyServer creates a PrivCount secret handshake key:
+    * each ShareKeeper and DataCollector needs to know this key to
+      successfully handshake with the TallyServer
+    * The configuration item for this key is a file path:
+      tally_server:
+        secret_handshake: 'keys/secret_handshake.yaml'
+      share_keeper:
+        secret_handshake: 'keys/secret_handshake.yaml'
+      data_collector:
+        secret_handshake: 'keys/secret_handshake.yaml'
+    * the file should be secretly and authentically transferred to the
+      ShareKeeper and DataCollector operators: encrypted, signed emails are a
+      good choice
+    * the client and server prove knowledge of the key without revealing it,
+      using a hash construction similar to tor's SAFECOOKIE authentication 
+      (for more details, see privcount/protocol.py)
+    * this key must be kept secret: it is equivalent to a symmetric secret key
+
+Each ShareKeeper creates a RSA key pair for public key encryption:
+     * each DataCollector needs to know the SHA256 hash of the public key of
+       each ShareKeeper
+     * the configuration item for this key is an array of hexadecimal
+       fingerprints:
+       data_collector:
+         share_keepers:
+         - 'e79ea9173e28e6a54f6d2ec6494c1723a330811652acebbe8d98098ce347d679'
+    * the fingerprints can be generated from the ShareKeeper keys using:
+        openssl rsa -pubout < keys/sk.pem | sha256sum
+    * the fingerprints should be authentically transferred to the
+      DataCollector operators: signed emails are a good choice
+    * the DataCollectors receive the ShareKeeper public keys via the PrivCount
+      protocol, and check that those keys match the configured fingerprints
+    * the DataCollectors use these keys to encrypt the blinding shares for
+      each ShareKeeper
+      (see data_collector.py and share_keeper.py for more details)
+    * the public keys and their fingerprints do not need to be kept secret,
+      but they must be transferred authentically
+    * the private keys on each ShareKeeper must be kept secret

--- a/doc/TorControlAuthentication.markdown
+++ b/doc/TorControlAuthentication.markdown
@@ -1,0 +1,100 @@
+# Tor Control Authentication
+
+PrivCount securely authenticates to tor's control port using cookie or password
+authentication. This protects against local port accesses (via web pages,
+compromised services, or other users) being used to run arbitrary processes as
+the tor user.
+
+## Choosing a Control Connection Type
+
+In general, controlling tor over a unix socket is more secure than an IP port:
+only processes with the correct filesystem permissions have access to a unix
+socket, while any process can connect to a port on localhost.
+
+Unix sockets also perform better than IP sockets, because they have no TCP and
+packet overheads.
+
+### Control Unix Socket
+
+Unix sockets are secured by filesystem permissions, but are a bit more complex
+to set up. Some OSs configure them automatically.
+
+#### Configure Control Socket in the torrc:
+  echo "ControlPort unix:/var/run/tor/control" >> torrc
+  (Your OS may have a different default, check the documentation)
+
+#### If you have separate PrivCount and Tor users:
+##### Add the PrivCount user to the tor user's group:
+  (These user names depend on your distribution and PrivCount config)
+  adduser privcount tor
+  Add the following flags to the end of the ControlPort line in the torrc:
+  GroupWritable
+
+#### If you still get permissions errors:
+##### Relax Directory Permissions
+  Add the following flags to the end of the ControlPort line in the torrc:
+  RelaxDirModeCheck
+
+#### Configure Control Socket in PrivCount
+  data_collector:
+    event_source:
+      unix: '/var/run/tor/control'
+
+### Control Port
+
+Control Ports are vulnerable to cross-protocol attacks, embedded content
+attacks (for example, web browsers) and privilege escalation from local
+processes.
+
+#### Configure Control Port in the torrc:
+  echo "ControlPort 9051" >> torrc
+
+#### Configure Control Port in PrivCount
+  data_collector:
+    event_source:
+      port: 9051
+
+## Configuring Cookie File Authentication
+
+Cookie authentication is secure as long as the cookie file is only readable
+by the PrivCount user. The cookie file is owned by the tor user.
+
+This is the simplest and most secure authentication method to configure, but
+relies on filesystem and user/group security.
+
+### Configure Cookie Authentication in the torrc:
+  echo "CookieAuthentication 1" >> torrc
+
+### If you have separate PrivCount and Tor users:
+#### Add the PrivCount user to the tor user's group:
+  (These user names depend on your distribution and PrivCount config)
+  adduser privcount tor
+#### Make the CookieAuthFile group-readable:
+  echo "CookieAuthFileGroupReadable 1" >> torrc
+
+## Configuring Password Authentication
+
+Password authentication requires a shared secret configured using the
+event_source's control_password option.
+
+### Generate a random 32-byte hexadecimal password using:
+  cat /dev/random | hexdump -e '"%x"' -n 32 -v > keys/control_password.txt
+### Configure your data collector with the plain text password file:
+  data_collector:
+    event_source:
+      control_password: 'keys/control_password.txt'
+  (PrivCount will fail if given an empty or non-existent password file.)
+### Hash the password and add it to the torrc
+  echo -n "HashedControlPassword " >> torrc
+  tor --hash-password `cat keys/control_password.txt` >> torrc
+
+## Implementation Details
+
+Tor can be configured with a cookie file and any number of hashed passwords.
+The PrivCount injector and data collector can be configured with a password
+file and a cookie file. The injector will accept either method; the data
+collector will use cookie authentication if both are configured.
+
+Tor control authentication is not supported when a PrivCount data collector is
+configured to connect to multiple event sources. Multiple event sources are
+intended for testing purposes only.

--- a/privcount/inject.py
+++ b/privcount/inject.py
@@ -256,7 +256,7 @@ def add_inject_args(parser):
                         help="do not inject events that occurred after the given unix timestamp",
                         default=2147483647)
     parser.add_argument('--control-password',
-                        help="The tor control password. Set this in tor using tor --hash-password and HashedControlPassword")
+                        help="A file containing the tor control password. Set this in tor using tor --hash-password and HashedControlPassword")
     parser.add_argument('--control-cookie-file',
                         help="The tor control cookie file. Set this in tor using CookieAuthentication and CookieAuthFile")
 

--- a/privcount/protocol.py
+++ b/privcount/protocol.py
@@ -983,6 +983,8 @@ class TorControlProtocol(object):
     SAFECOOKIE_SERVER_NONCE_LENGTH = 32
     SAFECOOKIE_SERVER_HASH_LENGTH = 32
 
+    # The security of SAFECOOKIE authentication does not depend on the client
+    # nonce
     SAFECOOKIE_CLIENT_NONCE_MIN_VALID_LENGTH = 0
     # An arbitrary limit, 1 kilobyte is quite enough to hash
     SAFECOOKIE_CLIENT_NONCE_MAX_VALID_LENGTH = 1024

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -71,10 +71,10 @@ data_collector:
         port: 20003
         #ip: 127.0.0.1 # optional (default 127.0.0.1), use ::1 for IPv6
         unix: '/tmp/privcount-inject' # control socket path. Tor defaults to /var/run/tor/control in many common distributions.
-        #control_password: ''
-        # a password for tor controller authentication
-        # set HashedControlPassword with the output of tor --hash-password ...
-        # passwords are not supported with multiple connection methods
+        control_password: 'keys/control_password.txt'
+        # cat /dev/random | hexdump -e '"%x"' -n 32 -v
+        # tor --hash-password
+        # Add HashedControlPassword to torrc
     tally_server_info: # where the tally server is located
         ip: 127.0.0.1
         port: 20001

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -87,10 +87,16 @@ $MOVE_LOG_COMMAND || true
 # We can either test --simulate, and get partial data, or get full data
 # It's better to get full data
 INJECTOR_BASE_CMD="privcount inject --log events.txt"
-# Use NULL authentication, because password authentication requires hard-coding
-# a value, and people might re-use it without thinking of security
-INJECTOR_PORT_CMD="$INJECTOR_BASE_CMD --port 20003" # --control-password
-# Use safecookie authentication (our client prefers SAFECOOKIE to PASSWORD)
+
+# Prepare for password authentication: the data collector and injector both
+# read this file
+echo "Generating random password file..."
+cat /dev/random | hexdump -e '"%x"' -n 32 -v > keys/control_password.txt
+# The command for password authentication
+INJECTOR_PORT_CMD="$INJECTOR_BASE_CMD --port 20003 --control-password keys/control_password.txt"
+
+# The injector automatically writes its own cookie file, just like tor
+# The command for safecookie authentication
 INJECTOR_UNIX_CMD="$INJECTOR_BASE_CMD --unix /tmp/privcount-inject --control-cookie-file /tmp/privcount-control-auth-cookie"
 
 # Generate a log file name


### PR DESCRIPTION
Make password security better by specifying the password in a separate file, not on the command-line or in a config file.

Document Tor Control Port authentication in doc/TorControlAuthentication.markdown, including Socket vs IP Port, and Cookie and Password authentication.
    
Document PrivCount authentication in doc/PrivCountAuthentication.markdown, including SSL, PrivCount handshake, and blinding share encryption.
