### PR TITLE
Show the NULL authentication warning (if it appears)

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -245,7 +245,6 @@ fi
 echo "Extracting warnings from privcount output..."
 grep -v -e NOTICE -e INFO -e DEBUG \
   -e "seconds of user activity" -e "delay_period not specified" \
-  -e "control port has no authentication" \
   privcount.*.latest.log \
   || true
 


### PR DESCRIPTION
Since #172, we use password and cookie authentication, so we don't need to
hide the "no authentication" warning any more.

Closes #183