### PR TITLE
Fix markdown formatting in Authentication docs

### DIFF
--- a/doc/PrivCountAuthentication.markdown
+++ b/doc/PrivCountAuthentication.markdown
@@ -3,45 +3,51 @@
 On first run, PrivCount creates the keys that it needs to run:
 
 The TallyServer creates a RSA key pair for SSL encryption:
-    * client SSL certificate fingerprint checks are not yet implemented
-    * no configuration is required
-    * the private key must be kept secret
+* client SSL certificate fingerprint checks are not yet implemented
+* no configuration is required
+* the private key must be kept secret
 
 The TallyServer creates a PrivCount secret handshake key:
-    * each ShareKeeper and DataCollector needs to know this key to
-      successfully handshake with the TallyServer
-    * The configuration item for this key is a file path:
-      tally_server:
-        secret_handshake: 'keys/secret_handshake.yaml'
-      share_keeper:
-        secret_handshake: 'keys/secret_handshake.yaml'
-      data_collector:
-        secret_handshake: 'keys/secret_handshake.yaml'
-    * the file should be secretly and authentically transferred to the
-      ShareKeeper and DataCollector operators: encrypted, signed emails are a
-      good choice
-    * the client and server prove knowledge of the key without revealing it,
-      using a hash construction similar to tor's SAFECOOKIE authentication
-      (for more details, see privcount/protocol.py)
-    * this key must be kept secret: it is equivalent to a symmetric secret key
+* each ShareKeeper and DataCollector needs to know this key to
+  successfully handshake with the TallyServer
+* The configuration item for this key is a file path:
+```
+  tally_server:
+    secret_handshake: 'keys/secret_handshake.yaml'
+  share_keeper:
+    secret_handshake: 'keys/secret_handshake.yaml'
+  data_collector:
+    secret_handshake: 'keys/secret_handshake.yaml'
+```
+* the file should be secretly and authentically transferred to the
+  ShareKeeper and DataCollector operators: encrypted, signed emails are a
+  good choice
+* the client and server prove knowledge of the key without revealing it,
+  using a hash construction similar to tor's SAFECOOKIE authentication
+  (for more details, see privcount/protocol.py)
+* this key must be kept secret: it is equivalent to a symmetric secret key
 
 Each ShareKeeper creates a RSA key pair for public key encryption:
-     * each DataCollector needs to know the SHA256 hash of the public key of
-       each ShareKeeper
-     * the configuration item for this key is an array of hexadecimal
-       fingerprints:
-       data_collector:
-         share_keepers:
-         - 'e79ea9173e28e6a54f6d2ec6494c1723a330811652acebbe8d98098ce347d679'
-    * the fingerprints can be generated from the ShareKeeper keys using:
-        openssl rsa -pubout < keys/sk.pem | sha256sum
-    * the fingerprints should be authentically transferred to the
-      DataCollector operators: signed emails are a good choice
-    * the DataCollectors receive the ShareKeeper public keys via the PrivCount
-      protocol, and check that those keys match the configured fingerprints
-    * the DataCollectors use these keys to encrypt the blinding shares for
-      each ShareKeeper
-      (see data_collector.py and share_keeper.py for more details)
-    * the public keys and their fingerprints do not need to be kept secret,
-      but they must be transferred authentically
-    * the private keys on each ShareKeeper must be kept secret
+* each DataCollector needs to know the SHA256 hash of the public key of
+  each ShareKeeper
+* the configuration item for this key is an array of hexadecimal
+  fingerprints:
+```
+  data_collector:
+    share_keepers:
+      - 'e79ea9173e28e6a54f6d2ec6494c1723a330811652acebbe8d98098ce347d679'
+```
+* the fingerprints can be generated from the ShareKeeper keys using:
+```
+  openssl rsa -pubout < keys/sk.pem | sha256sum
+```
+* the fingerprints should be authentically transferred to the
+  DataCollector operators: signed emails are a good choice
+* the DataCollectors receive the ShareKeeper public keys via the PrivCount
+  protocol, and check that those keys match the configured fingerprints
+* the DataCollectors use these keys to encrypt the blinding shares for
+  each ShareKeeper
+  (see data_collector.py and share_keeper.py for more details)
+* the public keys and their fingerprints do not need to be kept secret,
+  but they must be transferred authentically
+* the private keys on each ShareKeeper must be kept secret

--- a/doc/TorControlAuthentication.markdown
+++ b/doc/TorControlAuthentication.markdown
@@ -20,25 +20,46 @@ Unix sockets are secured by filesystem permissions, but are a bit more complex
 to set up. Some OSs configure them automatically.
 
 #### Configure Control Socket in the torrc:
+
+```
   echo "ControlPort unix:/var/run/tor/control" >> torrc
-  (Your OS may have a different default, check the documentation)
+```
+(Your OS may have a different default, check the documentation)
 
 #### If you have separate PrivCount and Tor users:
+
 ##### Add the PrivCount user to the tor user's group:
-  (These user names depend on your distribution and PrivCount config)
+
+(These user names depend on your distribution and PrivCount config)
+```
   adduser privcount tor
-  Add the following flags to the end of the ControlPort line in the torrc:
+```
+
+#### Make the Control Port socket group writeable:
+
+Add the following flags to the end of the ControlPort unix socket
+line in the torrc:
+```
   GroupWritable
+```
 
 #### If you still get permissions errors:
+
 ##### Relax Directory Permissions
-  Add the following flags to the end of the ControlPort line in the torrc:
+
+Add the following flags to the end of the ControlPort line in the torrc:
+```
   RelaxDirModeCheck
+```
 
 #### Configure Control Socket in PrivCount
+
+Add the following item to config.yaml:
+```
   data_collector:
     event_source:
       unix: '/var/run/tor/control'
+```
 
 ### Control Port
 
@@ -47,12 +68,19 @@ attacks (for example, web browsers) and privilege escalation from local
 processes.
 
 #### Configure Control Port in the torrc:
+
+```
   echo "ControlPort 9051" >> torrc
+```
 
 #### Configure Control Port in PrivCount
+
+Add the following item to config.yaml:
+```
   data_collector:
     event_source:
       port: 9051
+```
 
 ## Configuring Cookie File Authentication
 
@@ -63,14 +91,25 @@ This is the simplest and most secure authentication method to configure, but
 relies on filesystem and user/group security.
 
 ### Configure Cookie Authentication in the torrc:
+
+```
   echo "CookieAuthentication 1" >> torrc
+```
 
 ### If you have separate PrivCount and Tor users:
+
 #### Add the PrivCount user to the tor user's group:
-  (These user names depend on your distribution and PrivCount config)
+
+(These user names depend on your distribution and PrivCount config)
+```
   adduser privcount tor
+```
+
 #### Make the CookieAuthFile group-readable:
+
+```
   echo "CookieAuthFileGroupReadable 1" >> torrc
+```
 
 ## Configuring Password Authentication
 
@@ -78,15 +117,28 @@ Password authentication requires a shared secret configured using the
 event_source's control_password option.
 
 ### Generate a random 32-byte hexadecimal password using:
+
+```
   cat /dev/random | hexdump -e '"%x"' -n 32 -v > keys/control_password.txt
+```
+
 ### Configure your data collector with the plain text password file:
+
+Add the following item to config.yaml:
+```
   data_collector:
     event_source:
       control_password: 'keys/control_password.txt'
-  (PrivCount will fail if given an empty or non-existent password file.)
+```
+(PrivCount will fail if given an empty or non-existent password file, or a
+password file that's too short.)
+
 ### Hash the password and add it to the torrc
+
+```
   echo -n "HashedControlPassword " >> torrc
   tor --hash-password `cat keys/control_password.txt` >> torrc
+```
 
 ## Implementation Details
 


### PR DESCRIPTION
This now looks good on GitHub, merging without a review.