### PR TITLE
Update PrivCount documentation based on tor bug fixes

### DIFF
--- a/doc/TorEvents.markdown
+++ b/doc/TorEvents.markdown
@@ -38,24 +38,24 @@ The information available to a Tor Relay depends on the role that relay plays
 in the data transfer. Relays can determine their role in the data transfer
 based on the commands they receive.
 
-Role     |  Connection | Circuit | Stream | Cell | Bytes | Additional
----------|-------------|---------|--------|------|-------|-----------------
-Guard~   | Yes         | Yes     | No     | Yes  | X&    | Client IP~
-Bridge   | Yes         | Yes     | No     | Yes  | X&    | Client IP~
-Middle   | X           | X       | No     | X    | X&    | (None)
-Exit     | Yes         | Yes     | Yes    | Yes  | Yes   | DNS^
-DirPort  | X           | NA      | NA     | NA   | X     | URL*, Client IP$
-BEGINDIR | X           | X       | X      | X    | X     | URL*, Client IP$
-HSDir    | X           | X       | X      | X    | X     | Onion Address+
-Intro    | Yes         | Yes     | No     | Yes  | X&    | Service Keys+
-Rend     | Yes         | Yes     | No     | Yes  | X&    | (None)
-Client@  | X           | X       | X      | X    | X     | DNS^
+Role     |  Connection | Circuit | Stream | Cell | Bytes  | Additional
+---------|-------------|---------|--------|------|--------|-----------------
+Guard~   | Y           | Y       | N/E    | Y    | N/C/E& | Client IP~
+Bridge   | Y           | Y       | N/E    | Y    | N/C/E& | Client IP~
+Middle   | N/C         | N/C     | N/E    | N/C  | N/C/E& |
+Exit     | Y           | Y       | Y      | Y    | Y      | DNS^
+DirPort  | N/C         | N/A     | N/A    | N/A  | N/C    | URL*, Client IP$
+BEGINDIR | N/C         | N/C     | N/C    | N/C  | N/C    | URL*, Client IP$
+HSDir    | N/C         | N/C     | N/C    | N/C  | N/C    | Onion Address+
+Intro    | Y           | Y       | N/E    | Y    | N/C/E& | Service Keys+
+Rend     | Y           | Y       | N/C    | Y    | N/C/E& |
+Client@  | N/C         | N/C     | N/C    | N/C  | N/C    | DNS^
 
 Usage:
-* Yes: Available and Collected
-* No: Not Available (The information is encrypted)
-* NA: Not Applicable (The information does not exist)
-* X: Available, but Excluded from Collection
+* Y: Available and Collected
+* N/C: Available, but not Collected (We choose not to collect this)
+* N/E: Available, but Encrypted (The relay does not have the keys needed to decrypt this)
+* N/A: Not Applicable (The data does not exist)
 
 Notes:
 * \~ "Guard" relays can be connected to clients, or Bridge relays, or other

--- a/doc/TorEvents.markdown
+++ b/doc/TorEvents.markdown
@@ -51,30 +51,33 @@ Intro    | Yes         | Yes     | No     | Yes  | X&    | Service Keys+
 Rend     | Yes         | Yes     | No     | Yes  | X&    | (None)
 Client@  | X           | X       | X      | X    | X     | DNS^
 
-\~ "Guard" relays can be connected to clients, or Bridge relays, or other
-   relays that aren't in the consensus. Other relays authenticate using RSA and
-   ed25519 keys, bridges and clients do not, and can not be distinguished.  
-\$ Most Directory requests are performed using a direct connection from the
-   client, others are performed using a 3-hop path.
-\^ Application protocols also leak any unencrypted (meta)data to Exit relays
-   and Tor Clients.  
-\* Directory requests contain information about the documents being downloaded.
-   Clients request all relay documents, but fetch hidden service descriptors
-   as-needed.  
-\+ HSDirs handle hidden service descriptor uploads and downloads over BEGINDIR.
-   The service keys can be matched with a hidden service descriptor if the
-   onion address is known. Next-generation (v3) hidden service descriptors
-   can only be decrypted if the onion address is already known. Clients always
-   perform HSDir uploads and downloads over a 3-hop connection.
-\& This role sees encrypted cells, including headers and padding, and can not
-   distinguish overheads from content.  
-\@ Onion services connect to the tor network as clients. Relays can also
-   perform client activities, like fetching a consensus.  
-
+Usage:
 * Yes: Available and Collected
 * No: Not Available (The information is encrypted)
 * NA: Not Applicable (The information does not exist)
 * X: Available, but Excluded from Collection
+
+Notes:
+* \~ "Guard" relays can be connected to clients, or Bridge relays, or other
+     relays that aren't in the consensus. Other relays authenticate using RSA
+     and ed25519 keys, bridges and clients do not, and can not be distinguished.  
+* \$ Most Directory requests are performed using a direct connection from the
+     client, others are performed using a 3-hop path.  
+* \^ Application protocols also leak any unencrypted (meta)data to Exit relays
+     and Tor Clients.  
+* \* Directory requests contain information about the documents being
+     downloaded. Clients request all relay documents, but fetch hidden service
+     descriptors as-needed.  
+* \+ HSDirs handle hidden service descriptor uploads and downloads over
+     BEGINDIR. The service keys can be matched with a hidden service
+     descriptor if the onion address is known. Next-generation (v3) hidden
+     service descriptors can only be decrypted if the onion address is already
+     known. Clients always perform HSDir uploads and downloads over a 3-hop
+     connection.  
+* \& This role sees encrypted cells, including headers and padding, and can
+     not distinguish overheads from content.  
+* \@ Onion services connect to the tor network as clients. Relays can also
+     perform client activities, like fetching a consensus.   
 
 When relays are relaying cells on a circuit, they can only see that the cell
 is a RELAY (or RELAY_EARLY) cell. Everything else is encrypted. (Each relay


### PR DESCRIPTION
We now document which available data we collect, and which we exclude.
@robgjansen, please check that this is what you expect.
(I think we should do any fixes in future releases.)

Remove references to bugs #189, #190, #191, #195, #199, and update the text
to match. The tor changes are in privcount/tor#4.

