### PR TITLE
Add a Tally Server config for PrivCountMaxCellEventsPerCircuit

### DIFF
--- a/privcount/tally_server.py
+++ b/privcount/tally_server.py
@@ -193,6 +193,10 @@ class TallyServer(ServerFactory, PrivCountServer):
             assert ts_conf['circuit_sample_rate'] >= 0.0
             assert ts_conf['circuit_sample_rate'] <= 1.0
 
+            ts_conf.setdefault('max_cell_events_per_circuit', -1)
+            ts_conf['max_cell_events_per_circuit'] = \
+                int(ts_conf['max_cell_events_per_circuit'])
+
             # the counter bin file
             if 'counters' in ts_conf:
                 ts_conf['counters'] = normalise_path(ts_conf['counters'])
@@ -924,6 +928,7 @@ class TallyServer(ServerFactory, PrivCountServer):
                                                 dc_uids,
                                                 counter_modulus(),
                                                 clock_padding,
+                                                self.config['max_cell_events_per_circuit'],
                                                 self.config['circuit_sample_rate'],
                                                 self.config)
         self.collection_phase.start()
@@ -1018,7 +1023,8 @@ class CollectionPhase(object):
 
     def __init__(self, period, counters_config, traffic_model_config, noise_config,
                  noise_weight_config, dc_threshold_config, sk_uids,
-                 sk_public_keys, dc_uids, modulus, clock_padding, circuit_sample_rate,
+                 sk_public_keys, dc_uids, modulus, clock_padding,
+                 max_cell_events_per_circuit, circuit_sample_rate,
                  tally_server_config):
         # store configs
         self.period = period
@@ -1033,6 +1039,7 @@ class CollectionPhase(object):
         self.dc_uids = dc_uids
         self.modulus = modulus
         self.clock_padding = clock_padding
+        self.max_cell_events_per_circuit = max_cell_events_per_circuit
         self.circuit_sample_rate = circuit_sample_rate
         # make a deep copy, so we can delete unnecesary keys
         self.tally_server_config = deepcopy(tally_server_config)
@@ -1230,6 +1237,7 @@ class CollectionPhase(object):
             config['dc_threshold'] = self.dc_threshold_config
             config['defer_time'] = self.clock_padding
             config['collect_period'] = self.period
+            config['max_cell_events_per_circuit'] = self.max_cell_events_per_circuit
             config['circuit_sample_rate'] = self.circuit_sample_rate
             logging.info("sending start comand with {} counters ({} bins) and requesting {} shares to data collector {}"
                          .format(len(config['counters']),

--- a/test/config.chutney.yaml
+++ b/test/config.chutney.yaml
@@ -29,6 +29,8 @@ tally_server:
     delay_period: 86400
     # Ignore some circuits, so we test this feature
     circuit_sample_rate: 0.5
+    # set a cell limit, so we test this feature
+    max_cell_events_per_circuit: 25
     key: 'keys/ts.pem'
     cert: 'keys/ts.cert'
     # if the key file does not exist, the TS creates a file with a random key

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -48,6 +48,7 @@ tally_server:
     #sigma_decrease_tolerance: 1.0e-6 # (default: 1.0e-6) the sigma value decrease that the node will tolerate before enforcing a delay
     continue: 2 # start another collection phase after finishing a previous collection phase. If this value is an integer, run that many rounds before stopping. (The TS always runs at least 1 round.)
     circuit_sample_rate: 1.0 # must be between 0.0 and 1.0. Smaller values sample fewer circuits. The injector ignores this option.
+    max_cell_events_per_circuit: 25 # Limit cells from Tor. Can be negative to receive all cells from Tor. The injector ignores this option.
     # optional overrides:
     key: 'keys/ts.pem' # path to the rsa private key
     cert: 'keys/ts.cert' # path to the public key certificate


### PR DESCRIPTION
The max_cell_events_per_circuit in the Tally Server config is used
by the Data Collectors to set PrivCountMaxCellEventsPerCircuit on
their tor instances.

This was written by closely following the circuit_sample_rate
implementation in commit e6f6893a60366da7de9de2f0f7d5088c8a3bd35b.

Refs #418