### PR TITLE
removing scipy dependency by replacing scip normal cdf with math

### DIFF
--- a/privcount/statistics_noise.py
+++ b/privcount/statistics_noise.py
@@ -2,7 +2,6 @@
 
 import logging
 import math
-import scipy.stats
 import yaml
 
 from privcount.counter import DEFAULT_SIGMA_TOLERANCE, DEFAULT_EPSILON_TOLERANCE, DEFAULT_SIGMA_RATIO_TOLERANCE, DEFAULT_DUMMY_COUNTER_NAME, is_circuit_sample_counter
@@ -15,8 +14,8 @@ def satisfies_dp(sensitivity, epsilon, delta, std):
     # find lowest value at which epsilon differential-privacy is satisfied
     lower_x = -(float(epsilon) * (std**2.0) / sensitivity) + sensitivity/2.0
     # determine lower tail probability of normal distribution w/ mean of zero
-    lower_tail_prob = scipy.stats.norm.cdf(lower_x, 0, std)
-    # explicitly return Boolean value to avoid returning numpy type
+    lower_tail_prob = (1.0 + math.erf(lower_x / std / math.sqrt(2.0))) / 2.0
+    # explicitly return Boolean value
     if (lower_tail_prob <= delta):
         return True
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ pyOpenSSL>=0.15.1
 pyasn1>=0.1.9
 pyasn1-modules>=0.0.8
 pycparser>=2.14
-scipy>=0.13.0
 service-identity>=16.0.0
 six>=1.10.0
 wsgiref>=0.1.2


### PR DESCRIPTION
Obsoletes #500 

This allows us to run privcount using pypy, which otherwise fails because of the scipy dependency.